### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -649,7 +649,7 @@ exit:
 
 static int manager_load(Manager *manager) {
         const char suffix[] = ".service";
-        _c_cleanup_(c_closedirp) DIR *dir;
+        _c_cleanup_(c_closedirp) DIR *dir = NULL;
         const char *dirpath;
         struct dirent *de;
         char *path;


### PR DESCRIPTION
At least the first one in launch is relevant as we're using autocleanup for a maybe-unitialized variable (in the case when we return in the first error path)