### PR TITLE
policy: make deinit NULL-resistant

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -623,6 +623,9 @@ void policy_init(Policy *policy) {
 }
 
 void policy_deinit(Policy *policy) {
+        if (!policy)
+                return;
+
         assert(!policy->registry);
         assert(!c_rbnode_is_linked(&policy->registry_node));
         assert(policy->uid == (uid_t)-1);


### PR DESCRIPTION
7d2969ef4856c33c0e3938414556c70e32dd8c2c is the first failing commit.

```
#0  0x00007f493896a61e in __strcmp_sse2_unaligned () from /usr/x86_64-pc-linux-gnu/lib/libc.so.6
No symbol table info available.
#1  0x0000000000413c0b in transmission_policy_check_allowed (policy=0x636578450000000c, subject=0x6365784500000008, interface=0x45a05d5d0 <error: Cannot access memory at address 0x45a05d5d0>, member=0x7ffc5a05d630 "", 
    path=0x413c0b <transmission_policy_check_allowed+68> "\213U\300H\213E\310M\211\301A\211\360H\211\306\350\324\375\377\377H\213E\330H\211\307\350\a\340\377\377\203\360\001\204\300\017\204", <incomplete sequence \336>, type=0) at ../dbus-broker-scm/src/policy.c:590
        decision = {deny = 83, priority = 23548136}
#2  0x0000000000413daf in policy_deinit (policy=0x0) at ../dbus-broker-scm/src/policy.c:626
        __PRETTY_FUNCTION__ = "policy_deinit"
#3  0x000000000040535d in bus_broadcast (bus=0x0, sender=0x1, filter=0x0, message=0x1660088) at ../dbus-broker-scm/src/bus.c:113
        c_internal_var_unique_4X = 8
        r = 0
        __func__ = "bus_broadcast"
#4  0x0000000000405698 in socket_is_running (socket=0x0) at ../dbus-broker-scm/src/dbus/socket.h:120
No locals.
#5  0x000000000041ab73 in driver_name_owner_changed (bus=0x0, name=0x0, old_owner=0x0, new_owner=0x0) at ../dbus-broker-scm/src/driver.c:600
        c_internal_var_unique_20X = 0
        old_owner_str = '\000' <repeats 16 times>, "\004\000\000\000\000\000\000\000\060"
        new_owner_str = '\000' <repeats 24 times>
        r = 0
        __PRETTY_FUNCTION__ = "driver_name_owner_changed"
        __func__ = "driver_name_owner_changed"
#6  0x000000000041ad41 in driver_name_activated (activation=0x0, receiver=0x0) at ../dbus-broker-scm/src/driver.c:635
        var = {data = 0x0, n_data = 0, poison = 0, n_root_type = 0 '\000', ro = false, big_endian = false, current = 0x0, levels = {{parent_types = 0x0, i_type = 0x0, n_parent_types = 0 '\000', n_type = 0 '\000', container = 0 '\000', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 0, index = 0}} <repeats 36 times>, {parent_types = 0x0, i_type = 0x419179 <driver_dvar_write_signature_out+19>, 
              n_parent_types = 4 '\004', n_type = 0 '\000', container = 0 '\000', allocated_parent_types = 0 '\000', i_buffer = 18446744073709551615, {n_buffer = 0, index = 0}}, {parent_types = 0x428888, i_type = 0x4289ac, n_parent_types = 190 '\276', n_type = 136 '\210', container = 66 'B', allocated_parent_types = 0 '\000', i_buffer = 23465424, {n_buffer = 140721818822224, index = 140721818822224}}, {
              parent_types = 0x7ffc5a05e630, i_type = 0x0, n_parent_types = 0 '\000', n_type = 0 '\000', container = 0 '\000', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 0, index = 0}}, {parent_types = 0x0, i_type = 0x0, n_parent_types = 0 '\000', n_type = 0 '\000', container = 0 '\000', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 0, index = 0}} <repeats 11 times>, {parent_types = 0x0, 
              i_type = 0x0, n_parent_types = 208 '\320', n_type = 13 '\r', container = 102 'f', allocated_parent_types = 0 '\000', i_buffer = 140721818822224, {n_buffer = 140721818822192, index = 140721818822192}}, {parent_types = 0x0, i_type = 0x0, n_parent_types = 0 '\000', n_type = 0 '\000', container = 0 '\000', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 0, index = 0}} <repeats 12 times>, {
              parent_types = 0x0, i_type = 0x4, n_parent_types = 48 '0', n_type = 230 '\346', container = 5 '\005', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 0, index = 0}}, {parent_types = 0x7ffc5a05e680, i_type = 0x41ad41 <driver_name_activated+232>, n_parent_types = 128 '\200', n_type = 171 '\253', container = 106 'j', allocated_parent_types = 0 '\000', i_buffer = 0, {n_buffer = 23465424, 
                index = 23465424}}}}
        sender = 0x342e313a
        skb = 0x16aab80
        skb_safe = 0x16cc6f4
        request = 0x0
        request_safe = 0x0
        r = 0
        __func__ = "driver_name_activated"
#7  0x000000000041b60c in driver_method_release_name (peer=0x16aab80, in_v=0x7ffc5a05f1a0, serial=8, out_v=0x7ffc5a05e750) at ../dbus-broker-scm/src/driver.c:790
        change = {name = 0x1660d70, old_owner = 0x0, new_owner = 0x16aad00}
        name = 0x16cc6f4 "org.freedesktop.Accounts"
        reply = 1
        r = 0
        __func__ = "driver_method_release_name"
#8  0x000000000041db14 in driver_dispatch_interface (peer=0x413ea0 <policy_new+3>, serial=32764, interface=0x16b3500 "\200\065k\001", member=0x0, path=0x0, signature=0x0, message=0x16cc580) at ../dbus-broker-scm/src/driver.c:1613
        r = 0
        __func__ = "driver_dispatch_interface"
#9  0x000000000041dc61 in driver_dispatch_interface (peer=0x16aab80, serial=8, interface=0x16cc6a0 "RequestName", member=0x16cc680 "/org/freedesktop/DBus", path=0x16cc675 "su", signature=0x16cc580 "\001", message=0x16cc675) at ../dbus-broker-scm/src/driver.c:1634
        r = 0
        __func__ = "driver_dispatch_interface"
#10 0x000000000041de17 in driver_goodbye (peer=0x41dc61 <driver_dispatch_interface+379>, silent=252) at ../dbus-broker-scm/src/driver.c:1655
        reply = 0x418f76 <c_ref_sub+113>
        reply_safe = 0x2
        rule = 0x16aab80
        rule_safe = 0x8016aab80
        ownership = 0x16cc6b8
        ownership_safe = 0x16cc6a0
        r = 23905920
        __func__ = "driver_goodbye"
#11 0x000000000041e7bd in driver_dispatch_internal (peer=0x16aab80, metadata=0x7ffc5a060160, filter=0x7ffc5a05fd30) at ../dbus-broker-scm/src/driver.c:1814
        c_internal_var_unique_106X = 1510341936
        r = 0
        __func__ = "driver_dispatch_internal"
#12 0x000000000041ebac in driver_dispatch (peer=0x16aab80, message=0x16cc580) at ../dbus-broker-scm/src/driver.c:1884
        metadata = {message = 0x16cc580, header = {type = 1 '\001', flags = 0 '\000', version = 1 '\001', serial = 8}, fields = {available = 334, path = 0x16cc680 "/org/freedesktop/DBus", interface = 0x16cc6b8 "org.freedesktop.DBus", member = 0x16cc6a0 "RequestName", error_name = 0x0, reply_serial = 0, destination = 0x16cc6d8 "org.freedesktop.DBus", sender = 0x0, signature = 0x16cc675 "su", unix_fds = 0}, args = {{
              element = 115 's', value = 0x16cc6f4}, {element = 0 '\000', value = 0x0} <repeats 63 times>}}
        filter = {type = 1 '\001', destination = 18446744073709551614, sender = 4, interface = 0x16cc6b8 "org.freedesktop.DBus", member = 0x16cc6a0 "RequestName", path = 0x16cc680 "/org/freedesktop/DBus", args = {0x16cc6f4 "org.freedesktop.Accounts", 0x0 <repeats 63 times>}, argpaths = {0x16cc6f4 "org.freedesktop.Accounts", 0x0 <repeats 63 times>}}
        r = 0
        __func__ = "driver_dispatch"
#13 0x000000000040fe84 in peer_get_peersec (fd=32764, labelp=0x0, lenp=0x16cc580) at ../dbus-broker-scm/src/peer.c:97
        label = 0x416c88 <c_list_splice+12> "H\211u\360H\213E\360H\211\307\350B\376\377\377\203\360\001\204\300t[H\213E\360H\213"
        l = 0x16aab80 "\020"
        len = 32764
        r = 0
        __func__ = "peer_get_peersec"
#14 0x00000000004176de in fdlist_new_with_fds (listp=0x7ffc5a060670, fds=0x7ffc5a060670, n_fds=23462144) at ../dbus-broker-scm/src/util/fdlist.c:37
        list = 0x0
        __func__ = "fdlist_new_with_fds"
#15 0x0000000000404bd1 in manager_run (manager=0x1660010) at ../dbus-broker-scm/src/broker/manager.c:208
        signew = {__val = {16386, 0 <repeats 15 times>}}
        sigold = {__val = {81922, 23462232, 0, 0, 4318429480, 140721818830760, 140721818830816, 4213361, 30064771072, 140721818830832, 16386, 0, 0, 0, 0, 0}}
        listener = 0x0
        safe = 0x7ffc5a060928
        r = 0
        __func__ = "manager_run"
#16 0x0000000000403daf in run () at ../dbus-broker-scm/src/broker/main.c:121
        manager = 0x1660010
        r = 0
        __func__ = "run"
#17 0x0000000000403e2b in main (argc=4, argv=0x7ffc5a060928) at ../dbus-broker-scm/src/broker/main.c:133
        r = 0
        __func__ = "main"

```