### PR TITLE
Add meson build option for selinux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,16 @@ dep_csundry = dependency('libcsundry', version: '>=1', fallback: [ 'c-sundry', '
 dep_dbus = dependency('dbus-1', version: '>=1.10', required: false)
 dep_glib = dependency('glib-2.0', version: '>=2.50', required: false)
 dep_libaudit = dependency('audit', version: '>=2.7.0', required: false)
-dep_libselinux = dependency('libselinux', version: '>=2.5', required: false)
 dep_libsystemd = dependency('libsystemd', version: '>=230', required: false)
 dep_math = cc.find_library('m')
 dep_systemd = dependency('systemd', required: false)
 dep_thread = dependency('threads')
 dep_expat = dependency('expat')
+
+use_selinux = get_option('selinux')
+if use_selinux
+        dep_libselinux = dependency('libselinux', version: '>=2.5')
+endif
 
 conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('selinux', type: 'boolean', value: false, description: 'SELinux support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,7 +49,7 @@ else
         ]
 endif
 
-if dep_libselinux.found()
+if use_selinux
         libdbus_broker_sources += [
                 'util/selinux.c',
         ]


### PR DESCRIPTION
This allows selinux support to be disabled even when libselinux is
installed.

Ref: https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies