### PR TITLE
util/selinux: move from using security IDs to using security contexts

### DIFF
--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -216,7 +216,7 @@ static int controller_method_add_listener(Controller *controller, const char *_p
         uint32_t fd_index;
         socklen_t n;
 
-        r = policy_registry_new(&policy, controller->sid);
+        r = policy_registry_new(&policy, controller->seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -15,7 +15,6 @@
 
 typedef struct Broker Broker;
 typedef struct Bus Bus;
-typedef struct BusSELinuxID BusSELinuxID;
 typedef struct Controller Controller;
 typedef struct ControllerName ControllerName;
 typedef struct ControllerListener ControllerListener;
@@ -63,7 +62,8 @@ struct ControllerListener {
 
 struct Controller {
         Broker *broker;
-        BusSELinuxID *sid;
+        char *seclabel;
+        size_t n_seclabel;
         Connection connection;
         CRBTree name_tree;
         CRBTree listener_tree;

--- a/src/bus/policy.h
+++ b/src/bus/policy.h
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include "dbus/protocol.h"
 
-typedef struct BusSELinuxID BusSELinuxID;
 typedef struct BusSELinuxRegistry BusSELinuxRegistry;
 typedef struct NameSet NameSet;
 typedef struct PolicyBatch PolicyBatch;
@@ -108,7 +107,7 @@ struct PolicyRegistry {
 
 struct PolicySnapshot {
         BusSELinuxRegistry *selinux;
-        BusSELinuxID *sid;
+        char *seclabel;
         size_t n_batches;
         PolicyBatch *batches[];
 };
@@ -122,7 +121,7 @@ void policy_batch_free(_Atomic unsigned long *n_refs, void *userdata);
 
 /* registry */
 
-int policy_registry_new(PolicyRegistry **registryp, BusSELinuxID *fallback_id);
+int policy_registry_new(PolicyRegistry **registryp, const char *fallback_seclabel);
 PolicyRegistry *policy_registry_free(PolicyRegistry *registry);
 
 int policy_registry_import(PolicyRegistry *registry, CDVar *v);
@@ -133,7 +132,7 @@ C_DEFINE_CLEANUP(PolicyRegistry *, policy_registry_free);
 
 int policy_snapshot_new(PolicySnapshot **snapshotp,
                         PolicyRegistry *registry,
-                        BusSELinuxID *sid,
+                        const char *context,
                         uint32_t uid,
                         const uint32_t *gids,
                         size_t n_gids);
@@ -144,7 +143,7 @@ int policy_snapshot_dup(PolicySnapshot *snapshot, PolicySnapshot **newp);
 int policy_snapshot_check_connect(PolicySnapshot *snapshot);
 int policy_snapshot_check_own(PolicySnapshot *snapshot, const char *name);
 int policy_snapshot_check_send(PolicySnapshot *snapshot,
-                               BusSELinuxID *subject_sid,
+                               const char *subject_context,
                                NameSet *subject,
                                const char *interface,
                                const char *method,

--- a/src/util/selinux-fallback.c
+++ b/src/util/selinux-fallback.c
@@ -20,12 +20,7 @@ const char *bus_selinux_policy_root(void) {
         return NULL;
 }
 
-int bus_selinux_id_init(BusSELinuxID **id, const char *seclabel) {
-        *id = NULL;
-        return 0;
-}
-
-int bus_selinux_registry_new(BusSELinuxRegistry **registryp, BusSELinuxID *fallback_id) {
+int bus_selinux_registry_new(BusSELinuxRegistry **registryp, const char *fallback_context) {
         *registryp = NULL;
         return 0;
 }
@@ -43,14 +38,14 @@ int bus_selinux_registry_add_name(BusSELinuxRegistry *registry, const char *name
 }
 
 int bus_selinux_check_own(BusSELinuxRegistry *registry,
-                          BusSELinuxID *id_owner,
+                          const char *owner_context,
                           const char *name) {
         return 0;
 }
 
 int bus_selinux_check_send(BusSELinuxRegistry *registry,
-                           BusSELinuxID *id_sender,
-                           BusSELinuxID *id_receiver) {
+                           const char *context_sender,
+                           const char *context_receiver) {
         return 0;
 }
 

--- a/src/util/selinux.h
+++ b/src/util/selinux.h
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 
 typedef struct BusSELinuxRegistry BusSELinuxRegistry;
-typedef struct BusSELinuxID BusSELinuxID;
 
 enum {
         _SELINUX_E_SUCCESS,
@@ -19,9 +18,7 @@ enum {
 bool bus_selinux_is_enabled(void);
 const char *bus_selinux_policy_root(void);
 
-int bus_selinux_id_init(BusSELinuxID **id, const char *seclabel);
-
-int bus_selinux_registry_new(BusSELinuxRegistry **registryp, BusSELinuxID *fallback_id);
+int bus_selinux_registry_new(BusSELinuxRegistry **registryp, const char *fallback_context);
 BusSELinuxRegistry *bus_selinux_registry_ref(BusSELinuxRegistry *registry);
 BusSELinuxRegistry *bus_selinux_registry_unref(BusSELinuxRegistry *registry);
 
@@ -30,11 +27,11 @@ C_DEFINE_CLEANUP(BusSELinuxRegistry *, bus_selinux_registry_unref);
 int bus_selinux_registry_add_name(BusSELinuxRegistry *registry, const char *name, const char *context);
 
 int bus_selinux_check_own(BusSELinuxRegistry *registry,
-                          BusSELinuxID *id_owner,
+                          const char *context_owner,
                           const char *name);
 int bus_selinux_check_send(BusSELinuxRegistry *registry,
-                           BusSELinuxID *id_sender,
-                           BusSELinuxID *id_receiver);
+                           const char *context_sender,
+                           const char *context_receiver);
 
 int bus_selinux_init_global(void);
 void bus_selinux_deinit_global(void);


### PR DESCRIPTION
The SID API is deprecated upstream, instead move to the
selinux_check_access() API which does the lookup from context to SID
internally. If this proves to have a significant overhead we should
work with upstream SELinux to come up with a non-deprecated solution.

Addresses issue #16.

Signed-off-by: Tom Gundersen <teg@jklm.no>