### PR TITLE
Properly fail activation requests if systemd cannot activate them

### DIFF
--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -317,7 +317,9 @@ static int controller_method_name_reset(Controller *controller, const char *path
         if (!name)
                 return CONTROLLER_E_NAME_NOT_FOUND;
 
-        controller_name_reset(name);
+        r = controller_name_reset(name);
+        if (r)
+                return error_trace(r);
 
         c_dvar_write(out_v, "()");
 

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -9,6 +9,7 @@
 #include "broker/controller.h"
 #include "bus/activation.h"
 #include "bus/bus.h"
+#include "bus/driver.h"
 #include "bus/policy.h"
 #include "dbus/connection.h"
 #include "dbus/message.h"
@@ -64,8 +65,14 @@ static int controller_name_new(ControllerName **namep, Controller *controller, c
 /**
  * controller_name_reset() - XXX
  */
-void controller_name_reset(ControllerName *name) {
-        activation_flush(&name->activation);
+int controller_name_reset(ControllerName *name) {
+        int r;
+
+        r = driver_name_activation_failed(&name->controller->broker->bus, &name->activation);
+        if (r)
+                return error_fold(r);
+
+        return 0;
 }
 
 /**

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -77,7 +77,7 @@ struct Controller {
 /* names */
 
 ControllerName *controller_name_free(ControllerName *name);
-void controller_name_reset(ControllerName *name);
+int controller_name_reset(ControllerName *name);
 int controller_name_activate(ControllerName *name);
 
 C_DEFINE_CLEANUP(ControllerName *, controller_name_free);

--- a/src/bus/activation.c
+++ b/src/bus/activation.c
@@ -63,6 +63,21 @@ int activation_init(Activation *a, Name *name, User *user) {
         return 0;
 }
 
+static int activation_flush(Activation *activation) {
+        ActivationRequest *request;
+        ActivationMessage *message;
+
+        /* XXX: send out error replies */
+
+        while ((message = c_list_first_entry(&activation->activation_messages, ActivationMessage, link)))
+                activation_message_free(message);
+
+        while ((request = c_list_first_entry(&activation->activation_requests, ActivationRequest, link)))
+                activation_request_free(request);
+
+        return 0;
+}
+
 /**
  * activation_deinit() - XXX
  */
@@ -91,21 +106,6 @@ static int activation_request(Activation *activation) {
                 return error_fold(r);
 
         activation->requested = true;
-        return 0;
-}
-
-int activation_flush(Activation *activation) {
-        ActivationRequest *request;
-        ActivationMessage *message;
-
-        /* XXX: send out error replies */
-
-        while ((message = c_list_first_entry(&activation->activation_messages, ActivationMessage, link)))
-                activation_message_free(message);
-
-        while ((request = c_list_first_entry(&activation->activation_requests, ActivationRequest, link)))
-                activation_request_free(request);
-
         return 0;
 }
 

--- a/src/bus/activation.h
+++ b/src/bus/activation.h
@@ -75,6 +75,4 @@ int activation_queue_message(Activation *activation,
                              Message *m);
 int activation_queue_request(Activation *activation, User *user, uint64_t sender_id, uint32_t serial);
 
-int activation_flush(Activation *activation);
-
 C_DEFINE_CLEANUP(Activation *, activation_deinit);

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -59,6 +59,8 @@ enum {
         _DRIVER_E_MAX,
 };
 
+int driver_name_activation_failed(Bus *bus, Activation *activation);
+
 int driver_dispatch(Peer *peer, Message *message);
 void driver_matches_cleanup(MatchOwner *owner, Bus *bus, User *user);
 int driver_goodbye(Peer *peer, bool silent);


### PR DESCRIPTION
This can happen if the unit in question has been masked (or if it does not exist, but that would be a configuration failure). In this case, the requesting client should not hang forever, but rather receive a proper error reply.

This addresses issue #28.