### PR TITLE
launch: use $bindir to spawn dbus-broker

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project(
 
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 add_project_arguments('-DPACKAGE_VERSION=' + meson.project_version(), language: 'c')
+add_project_arguments('-DBINDIR="' + join_paths(get_option('prefix'), get_option('bindir')) + '"', language: 'c')
 
 cc = meson.get_compiler('c')
 conf = configuration_data()

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -49,7 +49,7 @@ struct Manager {
         uint64_t service_ids;
 };
 
-static const char *     main_arg_broker = "/usr/bin/dbus-broker";
+static const char *     main_arg_broker = BINDIR "/dbus-broker";
 static bool             main_arg_force = false;
 static const char *     main_arg_listen = NULL;
 static const char *     main_arg_scope = "system";


### PR DESCRIPTION
Rather than hard-coding /usr/bin/, lets use $bindir. You can still
override it via --broker=, but the default should now be sufficient.