### PR TITLE
Add basic logging infrastructure

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -83,7 +83,7 @@ int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_byt
         else
                 return error_origin(-ENOTRECOVERABLE);
 
-        r = bus_init(&broker->bus, max_bytes, max_fds, max_matches, max_objects);
+        r = bus_init(&broker->bus, &broker->log, max_bytes, max_fds, max_matches, max_objects);
         if (r)
                 return error_fold(r);
 

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -83,6 +83,9 @@ int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_byt
         else
                 return error_origin(-ENOTRECOVERABLE);
 
+        /* XXX: make this run-time optional */
+        log_set_lossy(&broker->log, true);
+
         r = bus_init(&broker->bus, &broker->log, max_bytes, max_fds, max_matches, max_objects);
         if (r)
                 return error_fold(r);

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -15,6 +15,7 @@
 #include "util/user.h"
 
 int bus_init(Bus *bus,
+             Log *log,
              unsigned int max_bytes,
              unsigned int max_fds,
              unsigned int max_matches,
@@ -24,6 +25,7 @@ int bus_init(Bus *bus,
         int r;
 
         *bus = (Bus)BUS_NULL(*bus);
+        bus->log = log;
 
         random = (void *)getauxval(AT_RANDOM);
         assert(random);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -61,3 +61,6 @@ int bus_init(Bus *bus,
 void bus_deinit(Bus *bus);
 
 Peer *bus_find_peer_by_name(Bus *bus, Name **namep, const char *name);
+
+int bus_log_commit_policy_send(Bus *bus, uint64_t sender_id, uint64_t receiver_id, Message *message);
+int bus_log_commit_policy_receive(Bus *bus, uint64_t sender_id, uint64_t receiver_id, Message *message);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -21,10 +21,12 @@ enum {
 };
 
 typedef struct Bus Bus;
+typedef struct Log Log;
 typedef struct Message Message;
 typedef struct User User;
 
 struct Bus {
+        Log *log;
         User *user;
         pid_t pid;
         char guid[16];
@@ -51,6 +53,7 @@ struct Bus {
         }
 
 int bus_init(Bus *bus,
+             Log *log,
              unsigned int max_bytes,
              unsigned int max_fds,
              unsigned int max_matches,

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1552,8 +1552,14 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
 
         r = policy_snapshot_check_send(peer->policy, NULL, NULL, interface, member, path, message->header->type);
         if (r) {
-                if (r == POLICY_E_ACCESS_DENIED)
+                if (r == POLICY_E_ACCESS_DENIED) {
+                        log_append_here(peer->bus->log, LOG_WARNING, 0);
+                        r = bus_log_commit_policy_send(peer->bus, peer->id, ADDRESS_ID_INVALID, message);
+                        if (r)
+                                return error_fold(r);
+
                         return DRIVER_E_SEND_DENIED;
+                }
 
                 return error_fold(r);
         }

--- a/src/dbus/message.h
+++ b/src/dbus/message.h
@@ -11,6 +11,7 @@
 #include "dbus/protocol.h"
 
 typedef struct FDList FDList;
+typedef struct Log Log;
 typedef struct Message Message;
 typedef struct MessageHeader MessageHeader;
 typedef struct MessageMetadata MessageMetadata;
@@ -99,6 +100,8 @@ void message_free(_Atomic unsigned long *n_refs, void *userdata);
 
 int message_parse_metadata(Message *message);
 void message_stitch_sender(Message *message, uint64_t sender_id);
+
+void message_log_append(Message *message, Log *log);
 
 /* inline helpers */
 


### PR DESCRIPTION
We should log if any message deliver fails unexpectedly. For now, add the logging for policy failures, which is most likely the most fragile and hard to debug. In the future we will add more metadata to the logging and extend it to log in more cases.