### PR TITLE
Fix inverted {path,arg0}_namespace= match-logic

### DIFF
--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -308,11 +308,11 @@ static bool match_keys_match_filter(MatchKeys *keys, MatchFilter *filter) {
         if (keys->filter.path && !c_string_equal(keys->filter.path, filter->path))
                 return false;
 
-        if (keys->path_namespace && !match_string_prefix(keys->path_namespace, filter->path, '/', false))
+        if (keys->path_namespace && !match_string_prefix(filter->path, keys->path_namespace, '/', false))
                 return false;
 
         /* XXX: verify that arg0 is a (potentially single-label) bus name */
-        if (keys->arg0namespace && !match_string_prefix(keys->arg0namespace, filter->args[0], '.', false))
+        if (keys->arg0namespace && !match_string_prefix(filter->args[0], keys->arg0namespace, '.', false))
                 return false;
 
         for (unsigned int i = 0; i < C_ARRAY_SIZE(filter->args); i ++) {

--- a/src/bus/test-match.c
+++ b/src/bus/test-match.c
@@ -186,9 +186,13 @@ static void test_individual_matches(void) {
         assert(!test_match("path_namespace=/com/example/foo", &filter));
         filter.path = "/com/example/foo";
         assert(test_match("path_namespace=/com/example/foo", &filter));
-        assert(test_match("path_namespace=/com/example/foo/bar", &filter));
+        assert(!test_match("path_namespace=/com/example/foo/bar", &filter));
         assert(!test_match("path_namespace=/com/example/foobar", &filter));
-        assert(!test_match("path_namespace=/com/example", &filter));
+        assert(test_match("path_namespace=/com/example", &filter));
+        assert(!test_match("path_namespace=/com/ex", &filter));
+        assert(test_match("path_namespace=/com", &filter));
+        /* XXX: This fails but shouldn't! */
+        /* assert(test_match("path_namespace=/", &filter)); */
 
         /* arg0 */
         filter = (MatchFilter)MATCH_FILTER_INIT;
@@ -236,9 +240,11 @@ static void test_individual_matches(void) {
         assert(!test_match("arg0namespace=com.example.foo", &filter));
         filter.args[0] = "com.example.foo";
         assert(test_match("arg0namespace=com.example.foo", &filter));
-        assert(test_match("arg0namespace=com.example.foo.bar", &filter));
+        assert(!test_match("arg0namespace=com.example.foo.bar", &filter));
         assert(!test_match("arg0namespace=com.example.foobar", &filter));
-        assert(!test_match("arg0namespace=com.example", &filter));
+        assert(test_match("arg0namespace=com.example", &filter));
+        assert(!test_match("arg0namespace=com.ex", &filter));
+        assert(test_match("arg0namespace=com", &filter));
 }
 
 static void test_iterator(void) {


### PR DESCRIPTION
The {path,arg0}_namespace= keys filter for any path/arg0 that is equal
that they, or a descendent of their namespace. Right now, we
incorrectly match for ancestors.

While at it, extend the test cases and document failures we need to
look into.