### PR TITLE
units: order dbus-broker.service before basic.target

### DIFF
--- a/units/system/dbus-broker.service.in
+++ b/units/system/dbus-broker.service.in
@@ -1,9 +1,12 @@
 [Unit]
 Description=D-Bus System Message Bus
-Documentation=man:dbus-broker(1)
-Requires=dbus.socket
+Documentation=man:dbus-broker-launch(1)
+DefaultDependencies=false
+Before=basic.target shutdown.target
+Conflicts=shutdown.target
 
 [Service]
+Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
 ExecStart=@bindir@/dbus-broker-launch -v --scope system --listen inherit

--- a/units/user/dbus-broker.service.in
+++ b/units/user/dbus-broker.service.in
@@ -1,9 +1,12 @@
 [Unit]
 Description=D-Bus User Message Bus
-Documentation=man:dbus-broker(1)
-Requires=dbus.socket
+Documentation=man:dbus-broker-launch(1)
+DefaultDependencies=false
+Before=basic.target shutdown.target
+Conflicts=shutdown.target
 
 [Service]
+Sockets=dbus.socket
 ExecStart=@bindir@/dbus-broker-launch -v --scope user --listen inherit
 
 [Install]


### PR DESCRIPTION
At start-up this makes no (or very little) difference, but at shutdown
this ensures that basic.target is shutdown before dbus-broker.service
is. In particular, we want clients to have the chance to shutdown
gracefully without having IPC pulled out from under them.

Signed-off-by: Tom Gundersen <teg@jklm.no>