### PR TITLE
uid ranges

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ if use_launcher
         dep_libsystemd = dependency('libsystemd', version: '>=230')
         dep_systemd = dependency('systemd', version: '>=230')
 
+        add_project_arguments('-DSYSTEMUIDMAX=' + dep_systemd.get_pkgconfig_variable('systemuidmax'), language: 'c')
         conf.set('systemunitdir', dep_systemd.get_pkgconfig_variable('systemdsystemunitdir'))
         conf.set('userunitdir', dep_systemd.get_pkgconfig_variable('systemduserunitdir'))
 endif

--- a/src/bus/policy.c
+++ b/src/bus/policy.c
@@ -481,7 +481,6 @@ static int policy_registry_import_batch(PolicyRegistry *registry,
  */
 int policy_registry_import(PolicyRegistry *registry, CDVar *v) {
         PolicyRegistryNode *node;
-        uint32_t uidgid;
         int r;
 
         /* XXX: provide the type */
@@ -494,9 +493,15 @@ int policy_registry_import(PolicyRegistry *registry, CDVar *v) {
         c_dvar_read(v, "[");
 
         while (c_dvar_more(v)) {
-                c_dvar_read(v, "(u", &uidgid);
+                uint32_t uid_start, uid_end;
 
-                r = policy_registry_at_uid(registry, &node, uidgid);
+                c_dvar_read(v, "(uu", &uid_start, &uid_end);
+
+                /* XXX: support ranges */
+                if (uid_start != uid_end)
+                        return POLICY_E_INVALID;
+
+                r = policy_registry_at_uid(registry, &node, uid_start);
                 if (r)
                         return error_trace(r);
 
@@ -510,9 +515,11 @@ int policy_registry_import(PolicyRegistry *registry, CDVar *v) {
         c_dvar_read(v, "][");
 
         while (c_dvar_more(v)) {
-                c_dvar_read(v, "(u", &uidgid);
+                uint32_t gid;
 
-                r = policy_registry_at_gid(registry, &node, uidgid);
+                c_dvar_read(v, "(u", &gid);
+
+                r = policy_registry_at_gid(registry, &node, gid);
                 if (r)
                         return error_trace(r);
 

--- a/src/bus/policy.h
+++ b/src/bus/policy.h
@@ -18,6 +18,7 @@ typedef struct PolicyBatch PolicyBatch;
 typedef struct PolicyBatchName PolicyBatchName;
 typedef struct PolicyRegistry PolicyRegistry;
 typedef struct PolicyRegistryNode PolicyRegistryNode;
+typedef struct PolicyRegistryNodeIndex PolicyRegistryNodeIndex;
 typedef struct PolicySnapshot PolicySnapshot;
 typedef struct PolicyVerdict PolicyVerdict;
 typedef struct PolicyXmit PolicyXmit;
@@ -82,25 +83,38 @@ struct PolicyBatch {
                 .name_tree = C_RBTREE_INIT,                                     \
         }
 
+struct PolicyRegistryNodeIndex {
+        uint32_t uidgid_start;
+        uint32_t uidgid_end;
+};
+
+#define POLICY_REGISTRY_NODE_INDEX_NULL {                                       \
+                .uidgid_start = (uint32_t)-1,                                   \
+                .uidgid_end = (uint32_t)-1,                                     \
+        }
+
 struct PolicyRegistryNode {
-        uint32_t uidgid;
+        PolicyRegistryNodeIndex index;
         CRBTree *registry_tree;
         CRBNode registry_node;
         PolicyBatch *batch;
 };
 
 #define POLICY_REGISTRY_NODE_NULL(_x) {                                         \
+                .index = POLICY_REGISTRY_NODE_INDEX_NULL,                       \
                 .registry_node = C_RBNODE_INIT((_x).registry_node),             \
         }
 
 struct PolicyRegistry {
         BusSELinuxRegistry *selinux;
         PolicyBatch *default_batch;
+        CRBTree uid_range_tree;
         CRBTree uid_tree;
         CRBTree gid_tree;
 };
 
 #define POLICY_REGISTRY_NULL {                                                  \
+                .uid_range_tree = C_RBTREE_INIT,                                \
                 .uid_tree = C_RBTREE_INIT,                                      \
                 .gid_tree = C_RBTREE_INIT,                                      \
         }

--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -859,7 +859,7 @@ static int policy_export_xmit(Policy *policy, CList *list1, CList *list2, sd_bus
 
 #define POLICY_T                                                                \
                 "(" POLICY_T_BATCH ")"                                          \
-                "a(u(" POLICY_T_BATCH "))"                                      \
+                "a(uu(" POLICY_T_BATCH "))"                                     \
                 "a(u(" POLICY_T_BATCH "))"                                      \
                 "a(ss)"
 
@@ -894,16 +894,16 @@ int policy_export(Policy *policy, sd_bus_message *m) {
         if (r < 0)
                 return error_origin(r);
 
-        r = sd_bus_message_open_container(m, 'a', "(u(" POLICY_T_BATCH "))");
+        r = sd_bus_message_open_container(m, 'a', "(uu(" POLICY_T_BATCH "))");
         if (r < 0)
                 return error_origin(r);
 
         c_rbtree_for_each_entry(node, &policy->uid_tree, policy_node) {
-                r = sd_bus_message_open_container(m, 'r', "u(" POLICY_T_BATCH ")");
+                r = sd_bus_message_open_container(m, 'r', "uu(" POLICY_T_BATCH ")");
                 if (r < 0)
                         return error_origin(r);
 
-                r = sd_bus_message_append(m, "u", node->uidgid);
+                r = sd_bus_message_append(m, "uu", node->uidgid, node->uidgid);
                 if (r < 0)
                         return error_origin(r);
 

--- a/src/launch/policy.h
+++ b/src/launch/policy.h
@@ -13,6 +13,7 @@
 
 typedef struct Policy Policy;
 typedef struct PolicyNode PolicyNode;
+typedef struct PolicyNodeIndex PolicyNodeIndex;
 typedef struct PolicyRecord PolicyRecord;
 
 struct PolicyRecord {
@@ -59,8 +60,18 @@ struct PolicyRecord {
                 .link = C_LIST_INIT((_x).link),                                 \
         }
 
+struct PolicyNodeIndex {
+        uint32_t uidgid_start;
+        uint32_t uidgid_end;
+};
+
+#define POLICY_NODE_INDEX_NULL {                                                \
+                .uidgid_start = (uint32_t)-1,                                   \
+                .uidgid_end = (uint32_t)-1,                                     \
+        }                                                                       \
+
 struct PolicyNode {
-        uint32_t uidgid;
+        PolicyNodeIndex index;
         CRBTree *policy_tree;
         CRBNode policy_node;
 
@@ -71,7 +82,7 @@ struct PolicyNode {
 };
 
 #define POLICY_NODE_NULL(_x) {                                                  \
-                .uidgid = (uint32_t)-1,                                         \
+                .index = POLICY_NODE_INDEX_NULL,                                \
                 .policy_node = C_RBNODE_INIT((_x).policy_node),                 \
                 .connect_list = C_LIST_INIT((_x).connect_list),                 \
                 .own_list = C_LIST_INIT((_x).own_list),                         \


### PR DESCRIPTION
Allow pseudo-compatibility with at_console= policies, by considering all system users at_console=false and all regular users at_console=true. This is done by allowing the UID specified in the broker API to be an upper/lower bound in addition to an exact match.