### PR TITLE
build: fallback to rst2man.py

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ add_project_arguments('-DBINDIR="' + join_paths(get_option('prefix'), get_option
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
-prog_rst2man = find_program('rst2man')
+prog_rst2man = find_program('rst2man', 'rst2man.py')
 
 sub_cdvar = subproject('c-dvar', version: '>=1')
 sub_clist = subproject('c-list', version: '>=3')


### PR DESCRIPTION
Some distributions don't rename the scripts to remote the .py extension