### PR TITLE
launch: increase listener backlog to SOMAXCONN

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -261,7 +261,21 @@ static int manager_listen_path(Manager *manager, const char *path) {
         if (r < 0)
                 return error_origin(-errno);
 
-        r = listen(s, 256);
+        /*
+         * The backlog parameter selects the maximum number of pending
+         * connections on a listener socket. Unfortunately, there is no fair
+         * queue sharing available, so any malicious peer can easily exhaust
+         * this limit.
+         *
+         * On linux, this limit is capped to `net/core/somaxconn` sysctl, which
+         * is 1024 by default. We simply use the same default value due to lack
+         * of any other reasonable choice.
+         *
+         * Preferably, we would tie this to our quota-infrastructure somehow.
+         * Unfortunately, there is still no mechanism to control this. Hence,
+         * we simply stick to the same limits everyone else uses on AF_UNIX.
+         */
+        r = listen(s, 1024);
         if (r < 0)
                 return error_origin(-errno);
 


### PR DESCRIPTION
Until today, we used a rather random backlog limit for AF_UNIX listener
sockets. However, it turns out the limit is used as literal limit on
linux to control the maximum number of pending connection attempts.
Since there is no fair queue sharing involved, all connecting users
share this single queue. Malicious peers can easily exhaust this limit
and cause connection failures for other peers.

Unfortunately, there is no known way to avoid this with AF_UNIX.
However, we can, at least, avoid the random magic number and stick to
the upstream limit. As it turns out, this is also what most other
AF_UNIX users do.

Additionally, document this situation. Fortunately, this will no longer
be an issue with bus1, since it employs fair queue sharing.