### PR TITLE
bus/driver: handle failure to send activation messages when sender is…

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -699,24 +699,36 @@ static int driver_name_activated(Activation *activation, Peer *receiver) {
                                         r = driver_send_error(sender, message_read_serial(message->message),
                                                               "org.freedesktop.DBus.Error.LimitsExceeded",
                                                               driver_error_to_string(DRIVER_E_QUOTA));
+                                else
+                                        r = 0;
+
                                 break;
                         case PEER_E_EXPECTED_REPLY_EXISTS:
                                 if (sender)
                                         r = driver_send_error(sender, message_read_serial(message->message),
                                                               "org.freedesktop.DBus.Error.AccessDenied",
                                                               driver_error_to_string(DRIVER_E_EXPECTED_REPLY_EXISTS));
+                                else
+                                        r = 0;
+
                                 break;
                         case PEER_E_RECEIVE_DENIED:
                                 if (sender)
                                         r = driver_send_error(sender, message_read_serial(message->message),
                                                               "org.freedesktop.DBus.Error.AccessDenied",
                                                               driver_error_to_string(DRIVER_E_RECEIVE_DENIED));
+                                else
+                                        r = 0;
+
                                 break;
                         case PEER_E_SEND_DENIED:
                                 if (sender)
                                         r = driver_send_error(sender, message_read_serial(message->message),
                                                               "org.freedesktop.DBus.Error.AccessDenied",
                                                               driver_error_to_string(DRIVER_E_SEND_DENIED));
+                                else
+                                        r = 0;
+
                                 break;
                         }
 


### PR DESCRIPTION
… NULL

If the sender is NULL, and the message could not be sent the error should be
silently ignored, not treated as fatal.

This should fix issue #66.

Signed-off-by: Tom Gundersen <teg@jklm.no>