### PR TITLE
Add SetPolicy() call to the controller

### DIFF
--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -11,7 +11,14 @@
 #include "util/dispatch.h"
 #include "util/log.h"
 
+enum {
+        _BROKER_E_SUCCESS,
+
+        BROKER_E_FORWARD_FAILED,
+};
+
 typedef struct Broker Broker;
+typedef struct User User;
 
 struct Broker {
         Log log;
@@ -31,6 +38,7 @@ Broker *broker_free(Broker *broker);
 
 int broker_run(Broker *broker);
 int broker_update_environment(Broker *broker, const char * const *env, size_t n_env);
+int broker_reload_config(Broker *broker, User *sender_user, uint64_t sender_id, uint32_t sender_serial);
 
 C_DEFINE_CLEANUP(Broker *, broker_free);
 

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -302,6 +302,10 @@ static int controller_method_name_release(Controller *controller, const char *pa
         if (!name)
                 return CONTROLLER_E_NAME_NOT_FOUND;
 
+        r = controller_name_reset(name);
+        if (r)
+                return error_trace(r);
+
         controller_name_free(name);
 
         c_dvar_write(out_v, "()");

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -142,7 +142,7 @@ static void controller_write_reply_header(CDVar *var, uint32_t serial, const CDV
 static int controller_send_error(Connection *connection, uint32_t serial, const char *error) {
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -162,6 +162,7 @@ static int controller_send_error(Connection *connection, uint32_t serial, const 
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = connection_queue(connection, NULL, message);
         if (r) {
@@ -374,7 +375,7 @@ static int controller_method_name_reset(Controller *controller, const char *path
 static int controller_handle_method(const ControllerMethod *method, Controller *controller, const char *path, uint32_t serial, const char *signature_in, Message *message_in) {
         _c_cleanup_(c_dvar_deinit) CDVar var_in = C_DVAR_INIT, var_out = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message_out = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -424,6 +425,7 @@ static int controller_handle_method(const ControllerMethod *method, Controller *
         r = message_new_outgoing(&message_out, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = connection_queue(&controller->connection, NULL, message_out);
         if (r) {
@@ -585,8 +587,8 @@ int controller_dbus_send_activation(Controller *controller, const char *path) {
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
-        void *data;
         int r;
 
         c_dvar_begin_write(&var, type, 1);
@@ -603,6 +605,7 @@ int controller_dbus_send_activation(Controller *controller, const char *path) {
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = connection_queue(&controller->connection, NULL, message);
         if (r)
@@ -631,8 +634,8 @@ int controller_dbus_send_environment(Controller *controller, const char * const 
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t i, n_data;
-        void *data;
         int r;
 
         c_dvar_begin_write(&var, type, 1);
@@ -655,6 +658,7 @@ int controller_dbus_send_environment(Controller *controller, const char * const 
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = connection_queue(&controller->connection, NULL, message);
         if (r)

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -53,12 +53,11 @@ struct ControllerMethod {
                 _body                                   \
         )
 
-static const CDVarType controller_type_in_ohsv[] = {
+static const CDVarType controller_type_in_ohv[] = {
         C_DVAR_T_INIT(
-                C_DVAR_T_TUPLE4(
+                C_DVAR_T_TUPLE3(
                         C_DVAR_T_o,
                         C_DVAR_T_h,
-                        C_DVAR_T_s,
                         C_DVAR_T_v
                 )
         )
@@ -210,7 +209,7 @@ static int controller_method_add_name(Controller *controller, const char *_path,
 
 static int controller_method_add_listener(Controller *controller, const char *_path, CDVar *in_v, FDList *fds, CDVar *out_v) {
         _c_cleanup_(policy_registry_freep) PolicyRegistry *policy = NULL;
-        const char *path, *policy_path;
+        const char *path;
         ControllerListener *listener;
         int r, listener_fd, v1, v2;
         uint32_t fd_index;
@@ -220,7 +219,7 @@ static int controller_method_add_listener(Controller *controller, const char *_p
         if (r)
                 return error_fold(r);
 
-        c_dvar_read(in_v, "(ohs", &path, &fd_index, &policy_path);
+        c_dvar_read(in_v, "(oh", &path, &fd_index);
 
         r = policy_registry_import(policy, in_v);
         if (r)
@@ -393,8 +392,8 @@ static int controller_handle_method(const ControllerMethod *method, Controller *
 
 static int controller_dispatch_controller(Controller *controller, uint32_t serial, const char *method, const char *path, const char *signature, Message *message) {
         static const ControllerMethod methods[] = {
-                { "AddName",            controller_method_add_name,     controller_type_in_osu,         controller_type_out_unit },
-                { "AddListener",        controller_method_add_listener, controller_type_in_ohsv,        controller_type_out_unit },
+                { "AddName",            controller_method_add_name,     controller_type_in_osu, controller_type_out_unit },
+                { "AddListener",        controller_method_add_listener, controller_type_in_ohv, controller_type_out_unit },
         };
 
         for (size_t i = 0; i < C_ARRAY_SIZE(methods); i++) {

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -10,6 +10,7 @@
 #include "bus/activation.h"
 #include "bus/bus.h"
 #include "bus/driver.h"
+#include "bus/listener.h"
 #include "bus/policy.h"
 #include "dbus/connection.h"
 #include "dbus/message.h"
@@ -123,6 +124,13 @@ static int controller_listener_new(ControllerListener **listenerp, Controller *c
         c_rbtree_add(&controller->listener_tree, parent, slot, &listener->controller_node);
         *listenerp = listener;
         return 0;
+}
+
+/**
+ * controller_listener_set_policy() - XXX
+ */
+int controller_listener_set_policy(ControllerListener *listener, PolicyRegistry *policy) {
+        return error_fold(listener_set_policy(&listener->listener, policy));
 }
 
 static int controller_dispatch_connection(DispatchFile *file) {

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -85,6 +85,7 @@ C_DEFINE_CLEANUP(ControllerName *, controller_name_free);
 /* listeners */
 
 ControllerListener *controller_listener_free(ControllerListener *listener);
+int controller_listener_set_policy(ControllerListener *listener, PolicyRegistry *policy);
 
 C_DEFINE_CLEANUP(ControllerListener *, controller_listener_free);
 

--- a/src/bus/activation.c
+++ b/src/bus/activation.c
@@ -63,29 +63,18 @@ int activation_init(Activation *a, Name *name, User *user) {
         return 0;
 }
 
-static int activation_flush(Activation *activation) {
+/**
+ * activation_deinit() - XXX
+ */
+void activation_deinit(Activation *activation) {
         ActivationRequest *request;
         ActivationMessage *message;
-
-        /* XXX: send out error replies */
 
         while ((message = c_list_first_entry(&activation->activation_messages, ActivationMessage, link)))
                 activation_message_free(message);
 
         while ((request = c_list_first_entry(&activation->activation_requests, ActivationRequest, link)))
                 activation_request_free(request);
-
-        return 0;
-}
-
-/**
- * activation_deinit() - XXX
- */
-void activation_deinit(Activation *activation) {
-        activation_flush(activation);
-
-        assert(c_list_is_empty(&activation->activation_messages));
-        assert(c_list_is_empty(&activation->activation_requests));
 
         activation->user = user_unref(activation->user);
 

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -391,7 +391,7 @@ static int driver_send_error(Peer *receiver, uint32_t serial, const char *error,
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -417,6 +417,7 @@ static int driver_send_error(Peer *receiver, uint32_t serial, const char *error,
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = driver_send_unicast(receiver, message);
         if (r)
@@ -427,7 +428,7 @@ static int driver_send_error(Peer *receiver, uint32_t serial, const char *error,
 
 static int driver_send_reply(Peer *peer, CDVar *var, uint32_t serial) {
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -451,6 +452,7 @@ static int driver_send_reply(Peer *peer, CDVar *var, uint32_t serial) {
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = driver_send_unicast(peer, message);
         if (r)
@@ -471,7 +473,7 @@ static int driver_notify_name_acquired(Peer *peer, const char *name) {
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -487,6 +489,7 @@ static int driver_notify_name_acquired(Peer *peer, const char *name) {
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = driver_send_unicast(peer, message);
         if (r)
@@ -507,7 +510,7 @@ static int driver_notify_name_lost(Peer *peer, const char *name) {
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -523,6 +526,7 @@ static int driver_notify_name_lost(Peer *peer, const char *name) {
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = driver_send_unicast(peer, message);
         if (r)
@@ -558,7 +562,7 @@ static int driver_notify_name_owner_changed(Bus *bus, const char *name, const ch
         };
         _c_cleanup_(c_dvar_deinit) CDVar var = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message = NULL;
-        void *data;
+        _c_cleanup_(c_freep) void *data = NULL;
         size_t n_data;
         int r;
 
@@ -574,6 +578,7 @@ static int driver_notify_name_owner_changed(Bus *bus, const char *name, const ch
         r = message_new_outgoing(&message, data, n_data);
         if (r)
                 return error_fold(r);
+        data = NULL;
 
         r = driver_monitor(bus, NULL, message);
         if (r)

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -31,6 +31,8 @@ enum {
         DRIVER_E_UNEXPECTED_SIGNATURE,
         DRIVER_E_UNEXPECTED_REPLY,
 
+        DRIVER_E_FORWARD_FAILED,
+
         DRIVER_E_QUOTA,
 
         DRIVER_E_UNEXPECTED_FLAGS,
@@ -60,6 +62,7 @@ enum {
 };
 
 int driver_name_activation_failed(Bus *bus, Activation *activation);
+int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 
 int driver_dispatch(Peer *peer, Message *message);
 void driver_matches_cleanup(MatchOwner *owner, Bus *bus, User *user);

--- a/src/bus/listener.c
+++ b/src/bus/listener.c
@@ -120,3 +120,26 @@ void listener_deinit(Listener *listener) {
         listener->socket_fd = c_close(listener->socket_fd);
         listener->bus = NULL;
 }
+
+/**
+ * listener_set_policy() - XXX
+ */
+int listener_set_policy(Listener *listener, PolicyRegistry *registry) {
+        Peer *peer;
+        int r;
+
+        c_list_for_each_entry(peer, &listener->peer_list, listener_link) {
+                PolicySnapshot *policy;
+
+                r = policy_snapshot_new(&policy, registry, peer->seclabel, peer->user->uid, peer->gids, peer->n_gids);
+                if (r)
+                        return error_fold(r);
+
+                policy_snapshot_free(peer->policy);
+                peer->policy = policy;
+        }
+
+        policy_registry_free(listener->policy);
+        listener->policy = registry;
+        return 0;
+}

--- a/src/bus/listener.c
+++ b/src/bus/listener.c
@@ -54,6 +54,8 @@ static int listener_dispatch(DispatchFile *file) {
                 return error_fold(r);
         fd = -1; /* consume fd */
 
+        c_list_link_tail(&listener->peer_list, &peer->listener_link);
+
         r = peer_spawn(peer);
         if (r)
                 return error_fold(r);

--- a/src/bus/listener.h
+++ b/src/bus/listener.h
@@ -37,4 +37,6 @@ int listener_init_with_fd(Listener *listener,
 Listener *listener_free(Listener *free);
 void listener_deinit(Listener *listener);
 
+int listener_set_policy(Listener *listener, PolicyRegistry *policy);
+
 C_DEFINE_CLEANUP(Listener *, listener_deinit);

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -187,6 +187,9 @@ int peer_new_with_fd(Peer **peerp,
         peer->user = user;
         user = NULL;
         peer->pid = ucred.pid;
+        peer->gids = gids;
+        gids = NULL;
+        peer->n_gids = n_gids;
         peer->seclabel = seclabel;
         seclabel = NULL;
         peer->n_seclabel = n_seclabel;
@@ -209,7 +212,7 @@ int peer_new_with_fd(Peer **peerp,
                 return error_fold(r);
         }
 
-        r = policy_snapshot_new(&peer->policy, policy, peer->seclabel, ucred.uid, gids, n_gids);
+        r = policy_snapshot_new(&peer->policy, policy, peer->seclabel, ucred.uid, peer->gids, peer->n_gids);
         if (r)
                 return error_fold(r);
 
@@ -263,6 +266,7 @@ Peer *peer_free(Peer *peer) {
         user_charge_deinit(&peer->charges[1]);
         user_charge_deinit(&peer->charges[0]);
         free(peer->seclabel);
+        free(peer->gids);
         free(peer);
 
         close(fd);

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -184,6 +184,7 @@ int peer_new_with_fd(Peer **peerp,
         peer->bus = bus;
         peer->connection = (Connection)CONNECTION_NULL(peer->connection);
         peer->registry_node = (CRBNode)C_RBNODE_INIT(peer->registry_node);
+        peer->listener_link = (CList)C_LIST_INIT(peer->listener_link);
         peer->user = user;
         user = NULL;
         peer->pid = ucred.pid;
@@ -251,6 +252,7 @@ Peer *peer_free(Peer *peer) {
         assert(!peer->registered);
 
         c_rbtree_remove_init(&peer->bus->peers.peer_tree, &peer->registry_node);
+        c_list_unlink_init(&peer->listener_link);
 
         fd = peer->connection.socket.fd;
 

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -62,6 +62,7 @@ struct Peer {
 
         uint64_t id;
         CRBNode registry_node;
+        CList listener_link;
 
         Connection connection;
         bool registered : 1;

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -54,6 +54,8 @@ struct Peer {
         Bus *bus;
         User *user;
         pid_t pid;
+        gid_t *gids;
+        size_t n_gids;
         char *seclabel;
         size_t n_seclabel;
         UserCharge charges[3];

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -943,10 +943,9 @@ static int manager_add_listener(Manager *manager) {
         if (r < 0)
                 return error_origin(r);
 
-        r = sd_bus_message_append(m, "ohs",
+        r = sd_bus_message_append(m, "oh",
                                   "/org/bus1/DBus/Listener/0",
-                                  manager->fd_listen,
-                                  policypath);
+                                  manager->fd_listen);
         if (r < 0)
                 return error_origin(r);
 

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -32,8 +32,15 @@ enum {
         MAIN_FAILED,
 };
 
+typedef enum {
+        SERVICE_STATE_PENDING,
+        SERVICE_STATE_CURRENT,
+        SERVICE_STATE_DEFUNCT,
+} ServiceState;
+
 struct Service {
         Manager *manager;
+        ServiceState state;
         sd_bus_slot *slot;
         CRBNode rb;
         CRBNode rb_by_name;
@@ -114,29 +121,10 @@ static Service *service_free(Service *service) {
 
 C_DEFINE_CLEANUP(Service *, service_free);
 
-static int service_new(Service **servicep,
-                       Manager *manager,
-                       const char *name,
-                       CRBNode **slot_by_name,
-                       CRBNode *parent_by_name,
-                       const char *unit,
-                       char **exec,
-                       size_t n_exec) {
-        _c_cleanup_(service_freep) Service *service = NULL;
-        CRBNode **slot, *parent;
-
-        service = calloc(1, sizeof(*service) + C_DECIMAL_MAX(uint64_t) + 1);
-        if (!service)
-                return error_origin(-ENOMEM);
-
-        service->manager = manager;
-        service->rb = (CRBNode)C_RBNODE_INIT(service->rb);
-        service->rb_by_name = (CRBNode)C_RBNODE_INIT(service->rb_by_name);
-        sprintf(service->id, "%" PRIu64, ++manager->service_ids);
-
-        service->name = strdup(name);
-        if (!service->name)
-                return error_origin(-ENOMEM);
+static int service_update(Service *service, const char *unit, char **exec, size_t n_exec) {
+        service->unit = c_free(service->unit);
+        service->exec = c_free(service->exec);
+        service->n_exec = 0;
 
         if (unit) {
                 service->unit = strdup(unit);
@@ -157,6 +145,38 @@ static int service_new(Service **servicep,
                                 return error_origin(-ENOMEM);
                 }
         }
+
+        return 0;
+}
+
+static int service_new(Service **servicep,
+                       Manager *manager,
+                       const char *name,
+                       CRBNode **slot_by_name,
+                       CRBNode *parent_by_name,
+                       const char *unit,
+                       char **exec,
+                       size_t n_exec) {
+        _c_cleanup_(service_freep) Service *service = NULL;
+        CRBNode **slot, *parent;
+        int r;
+
+        service = calloc(1, sizeof(*service) + C_DECIMAL_MAX(uint64_t) + 1);
+        if (!service)
+                return error_origin(-ENOMEM);
+
+        service->manager = manager;
+        service->rb = (CRBNode)C_RBNODE_INIT(service->rb);
+        service->rb_by_name = (CRBNode)C_RBNODE_INIT(service->rb_by_name);
+        sprintf(service->id, "%" PRIu64, ++manager->service_ids);
+
+        service->name = strdup(name);
+        if (!service->name)
+                return error_origin(-ENOMEM);
+
+        r = service_update(service, unit, exec, n_exec);
+        if (r)
+                return error_trace(r);
 
         slot = c_rbtree_find_slot(&manager->services, service_compare, service->id, &parent);
         assert(slot);
@@ -189,6 +209,22 @@ static Manager *manager_free(Manager *manager) {
 
 C_DEFINE_CLEANUP(Manager *, manager_free);
 
+static int manager_reload_config(Manager *manager);
+
+static int manager_on_sighup(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {
+        Manager *manager = userdata;
+        int r;
+
+        if (main_arg_verbose)
+                fprintf(stderr, "Caught SIGHUP\n");
+
+        r = manager_reload_config(manager);
+        if (r)
+                return error_fold(r);
+
+        return 1;
+}
+
 static int manager_new(Manager **managerp) {
         _c_cleanup_(manager_freep) Manager *manager = NULL;
         int r;
@@ -208,6 +244,10 @@ static int manager_new(Manager **managerp) {
                 return error_origin(r);
 
         r = sd_event_add_signal(manager->event, NULL, SIGINT, NULL, NULL);
+        if (r < 0)
+                return error_origin(r);
+
+        r = sd_event_add_signal(manager->event, NULL, SIGHUP, manager_on_sighup, manager);
         if (r < 0)
                 return error_origin(r);
 
@@ -745,8 +785,17 @@ static int manager_load_service_file(Manager *manager, const char *path) {
                         goto exit;
                 }
         } else {
-                fprintf(stderr, "Ignoring duplicate name '%s' in service file '%s'\n", name, path);
-                r = 0;
+                Service *old_service = c_container_of(parent, Service, rb_by_name);
+
+                if (old_service->state == SERVICE_STATE_DEFUNCT) {
+                        old_service->state = SERVICE_STATE_CURRENT;
+                        r = service_update(old_service, unit, exec, n_exec);
+                        if (r)
+                                r = error_trace(r);
+                } else {
+                        fprintf(stderr, "Ignoring duplicate name '%s' in service file '%s'\n", name, path);
+                        r = 0;
+                }
                 goto exit;
         }
 
@@ -817,6 +866,9 @@ static int manager_add_services(Manager *manager) {
         c_rbtree_for_each_entry(service, &manager->services, rb) {
                 _c_cleanup_(c_freep) char *object_path = NULL;
 
+                if (service->state != SERVICE_STATE_PENDING)
+                        continue;
+
                 r = asprintf(&object_path, "/org/bus1/DBus/Name/%s", service->id);
                 if (r < 0)
                         return error_origin(-ENOMEM);
@@ -834,6 +886,39 @@ static int manager_add_services(Manager *manager) {
                                        0);
                 if (r < 0)
                         return error_origin(r);
+
+                service->state = SERVICE_STATE_CURRENT;
+        }
+
+        return 0;
+}
+
+static int manager_remove_services(Manager *manager) {
+        Service *service, *service_safe;
+        int r;
+
+        c_rbtree_for_each_entry_safe(service, service_safe, &manager->services, rb) {
+                _c_cleanup_(c_freep) char *object_path = NULL;
+
+                if (service->state != SERVICE_STATE_DEFUNCT)
+                        continue;
+
+                r = asprintf(&object_path, "/org/bus1/DBus/Name/%s", service->id);
+                if (r < 0)
+                        return error_origin(-ENOMEM);
+
+                r = sd_bus_call_method(manager->bus_controller,
+                                       NULL,
+                                       object_path,
+                                       "org.bus1.DBus.Name",
+                                       "Release",
+                                       NULL,
+                                       NULL,
+                                       "");
+                if (r < 0)
+                        return error_origin(r);
+
+                service_free(service);
         }
 
         return 0;
@@ -991,6 +1076,62 @@ static int manager_add_listener(Manager *manager, Policy *policy) {
         return 0;
 }
 
+static int manager_set_policy(Manager *manager, Policy *policy) {
+        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+        int r;
+
+        r = sd_bus_message_new_method_call(manager->bus_controller,
+                                           &m,
+                                           NULL,
+                                           "/org/bus1/DBus/Listener/0",
+                                           "org.bus1.DBus.Listener",
+                                           "SetPolicy");
+        if (r < 0)
+                return error_origin(r);
+
+        r = policy_export(policy, m);
+        if (r)
+                return error_fold(r);
+
+        r = sd_bus_call(manager->bus_controller, m, 0, NULL, NULL);
+        if (r < 0)
+                return error_origin(r);
+
+        return 0;
+}
+
+static int manager_reload_config(Manager *manager) {
+        _c_cleanup_(config_root_freep) ConfigRoot *root = NULL;
+        _c_cleanup_(policy_deinit) Policy policy = POLICY_INIT(policy);
+        Service *service;
+        int r;
+
+        c_rbtree_for_each_entry(service, &manager->services, rb)
+                service->state = SERVICE_STATE_DEFUNCT;
+
+        r = manager_load_services(manager);
+        if (r)
+                return error_trace(r);
+
+        r = manager_load_policy(manager, &root, &policy);
+        if (r)
+                return error_trace(r);
+
+        r = manager_remove_services(manager);
+        if (r)
+                return error_trace(r);
+
+        r = manager_set_policy(manager, &policy);
+        if (r)
+                return error_trace(r);
+
+        r = manager_add_services(manager);
+        if (r)
+                return error_trace(r);
+
+        return 0;
+}
+
 static int manager_connect(Manager *manager) {
         _c_cleanup_(bus_close_unrefp) sd_bus *b = NULL;
         _c_cleanup_(c_closep) int s = -1;
@@ -1073,11 +1214,11 @@ static int manager_run(Manager *manager) {
         if (r)
                 return error_trace(r);
 
-        r = manager_add_services(manager);
+        r = manager_load_policy(manager, &root, &policy);
         if (r)
                 return error_trace(r);
 
-        r = manager_load_policy(manager, &root, &policy);
+        r = manager_add_services(manager);
         if (r)
                 return error_trace(r);
 
@@ -1298,6 +1439,7 @@ int main(int argc, char **argv) {
         sigaddset(&mask_new, SIGCHLD);
         sigaddset(&mask_new, SIGTERM);
         sigaddset(&mask_new, SIGINT);
+        sigaddset(&mask_new, SIGHUP);
 
         sigprocmask(SIG_BLOCK, &mask_new, &mask_old);
         r = run();

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -427,7 +427,6 @@ static int manager_fork(Manager *manager, int fd_controller) {
 }
 
 static int manager_start_unit_handler(sd_bus_message *message, void *userdata, sd_bus_error *errorp) {
-        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *method_call = NULL;
         _c_cleanup_(c_freep) char *object_path = NULL;
         const sd_bus_error *error;
         Service *service = userdata;
@@ -448,15 +447,14 @@ static int manager_start_unit_handler(sd_bus_message *message, void *userdata, s
         if (r < 0)
                 return error_origin(-errno);
 
-        r = sd_bus_message_new_method_call(service->manager->bus_controller, &method_call,
-                                           "org.bus1.DBus.Broker",
-                                           object_path,
-                                           "org.bus1.DBus.Name",
-                                           "Reset");
-        if (r < 0)
-                return error_origin(r);
-
-        r = sd_bus_send(service->manager->bus_controller, method_call, NULL);
+        r = sd_bus_call_method(service->manager->bus_controller,
+                               NULL,
+                               object_path,
+                               "org.bus1.DBus.Name",
+                               "Reset",
+                               NULL,
+                               NULL,
+                               "");
         if (r < 0)
                 return error_origin(r);
 

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -1257,6 +1257,27 @@ static void test_introspect(void) {
         util_broker_terminate(broker);
 }
 
+static void test_reload_config(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        /* call ReloadConfig and block until it succeeds */
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+
+                util_broker_connect(broker, &bus);
+
+                r = sd_bus_call_method(bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "ReloadConfig", NULL, NULL,
+                                       "");
+                assert(r >= 0);
+        }
+
+        util_broker_terminate(broker);
+}
 static void test_become_monitor(void) {
         _c_cleanup_(util_broker_freep) Broker *broker = NULL;
         int r;
@@ -1298,6 +1319,7 @@ int main(int argc, char **argv) {
         test_get_connection_unix_process_id();
         test_get_adt_audit_session_data();
         test_get_id();
+        test_reload_config();
         test_introspect();
         test_become_monitor();
 

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -121,7 +121,7 @@ static int util_append_policy(sd_bus_message *m) {
 
 void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp) {
         _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
-        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message = NULL;
+        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message = NULL, *message2 = NULL;
         _c_cleanup_(c_freep) char *fdstr = NULL;
         int r, pair[2];
         pid_t pid;
@@ -191,6 +191,20 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
         assert(r >= 0);
 
         r = sd_bus_call(bus, message, -1, NULL, NULL);
+        assert(r >= 0);
+
+        r = sd_bus_message_new_method_call(bus,
+                                           &message2,
+                                           NULL,
+                                           "/org/bus1/DBus/Listener/0",
+                                           "org.bus1.DBus.Listener",
+                                           "SetPolicy");
+        assert(r >= 0);
+
+        r = util_append_policy(message2);
+        assert(r >= 0);
+
+        r = sd_bus_call(bus, message2, -1, NULL, NULL);
         assert(r >= 0);
 
         *busp = bus;

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -163,11 +163,11 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
         r = sd_bus_new(&bus);
         assert(r >= 0);
 
-        r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
-        assert(r >= 0);
-
         /* consumes the fd */
         r = sd_bus_set_fd(bus, pair[0], pair[0]);
+        assert(r >= 0);
+
+        r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
         assert(r >= 0);
 
         r = sd_bus_start(bus);

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -182,10 +182,9 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
         assert(r >= 0);
 
         r = sd_bus_message_append(message,
-                                  "ohs",
+                                  "oh",
                                   "/org/bus1/DBus/Listener/0",
-                                  listener_fd,
-                                  NULL);
+                                  listener_fd);
         assert(r >= 0);
 
         r = util_append_policy(message);


### PR DESCRIPTION
The broker allows names to be added/removed and the policy to be set for an existing listener. Together, this allows replacing all the configuration at run-time.

The launcher reloads the configuration, then removes all names that are no longer present, sets the new policy on the listener (which in turn updates the policy of each of the peers spawned from the listener). This can either be triggered by raising SIGHUP in the launcher, or by calling the internal ReloadConfig() call from the broker.

The broker now exposes the standard ReloadConfig() call on the org.freedesktop.DBus API which is forwarded to the launcher.