### PR TITLE
audit: make audit optional at run-time and only enable when run in sy…

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -1419,6 +1419,8 @@ static int run(void) {
                         r = asprintf(&listen_path, "/var/run/user/%u/bus", getuid());
                 if (r < 0)
                         return error_origin(-ENOMEM);
+
+                path = listen_path;
         } else if (!strcmp(main_arg_scope, "system")) {
                 path = "/var/run/dbus/system_bus_socket";
         } else {


### PR DESCRIPTION
…stem scope

The broker now takes a new command-line option --audit to opt-in to the
audit subsystem, and the launcher will pass this only when run in the
system scope.

This addresses issue #68.

Signed-off-by: Tom Gundersen <teg@jklm.no>