### PR TITLE
units: hook up ExecReload

### DIFF
--- a/units/system/dbus-broker.service.in
+++ b/units/system/dbus-broker.service.in
@@ -10,6 +10,7 @@ Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
 ExecStart=@bindir@/dbus-broker-launch -v --scope system --listen inherit
+ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
 
 [Install]
 Alias=dbus.service

--- a/units/user/dbus-broker.service.in
+++ b/units/user/dbus-broker.service.in
@@ -8,6 +8,7 @@ Conflicts=shutdown.target
 [Service]
 Sockets=dbus.socket
 ExecStart=@bindir@/dbus-broker-launch -v --scope user --listen inherit
+ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
 
 [Install]
 Alias=dbus.service


### PR DESCRIPTION
Use busctl to call ReloadConfig() on dbus-broker.

$ systemctl --user reload dbus

can now be used to reload the dbus configuration in a blocking way.