### PR TITLE
launcher: rework nss handling

### DIFF
--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -14,6 +14,7 @@ typedef struct ConfigNode ConfigNode;
 typedef struct ConfigParser ConfigParser;
 typedef struct ConfigRoot ConfigRoot;
 typedef struct ConfigState ConfigState;
+typedef struct NSSCache NSSCache;
 
 #define CONFIG_PARSER_BUFFER_MAX 4096
 
@@ -181,6 +182,7 @@ struct ConfigParser {
         XML_Parser xml;
 
         struct ConfigState {
+                NSSCache *nss;
                 ConfigPath *file;
                 ConfigRoot *root;
                 ConfigNode *current;
@@ -222,6 +224,6 @@ C_DEFINE_CLEANUP(ConfigRoot *, config_root_free);
 void config_parser_init(ConfigParser *parser);
 void config_parser_deinit(ConfigParser *parser);
 
-int config_parser_read(ConfigParser *parser, ConfigRoot **rootp, const char *path);
+int config_parser_read(ConfigParser *parser, ConfigRoot **rootp, const char *path, NSSCache *nss_cache);
 
 C_DEFINE_CLEANUP(ConfigParser *, config_parser_deinit);

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -1122,7 +1122,7 @@ static int manager_load_services(Manager *manager, NSSCache *nss_cache) {
         return 0;
 }
 
-static int manager_load_policy(Manager *manager, ConfigRoot **rootp, Policy *policy) {
+static int manager_load_policy(Manager *manager, ConfigRoot **rootp, Policy *policy, NSSCache *nss_cache) {
         _c_cleanup_(config_parser_deinit) ConfigParser parser = CONFIG_PARSER_NULL(parser);
         const char *policypath;
         int r;
@@ -1138,7 +1138,7 @@ static int manager_load_policy(Manager *manager, ConfigRoot **rootp, Policy *pol
 
         config_parser_init(&parser);
 
-        r = config_parser_read(&parser, rootp, policypath);
+        r = config_parser_read(&parser, rootp, policypath, nss_cache);
         if (r)
                 return error_fold(r);
 
@@ -1219,7 +1219,7 @@ static int manager_reload_config(Manager *manager) {
         if (r)
                 return error_trace(r);
 
-        r = manager_load_policy(manager, &root, &policy);
+        r = manager_load_policy(manager, &root, &policy, &nss_cache);
         if (r)
                 return error_trace(r);
 
@@ -1344,7 +1344,7 @@ static int manager_run(Manager *manager, bool audit) {
         if (r)
                 return error_trace(r);
 
-        r = manager_load_policy(manager, &root, &policy);
+        r = manager_load_policy(manager, &root, &policy, &nss_cache);
         if (r)
                 return error_trace(r);
 

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -66,6 +66,11 @@ int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user) {
         CRBNode **slot, *parent;
         int r;
 
+        if (!strcmp(user, "root")) {
+                *uidp = 0;
+                return 0;
+        }
+
         slot = c_rbtree_find_slot(&cache->user_tree, nss_cache_node_compare, user, &parent);
         if (!slot) {
                 node = c_rbnode_entry(parent, NSSCacheNode, rb);
@@ -92,6 +97,11 @@ int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group) {
         NSSCacheNode *node;
         CRBNode **slot, *parent;
         int r;
+
+        if (!strcmp(group, "root")) {
+                *gidp = 0;
+                return 0;
+        }
 
         slot = c_rbtree_find_slot(&cache->group_tree, nss_cache_node_compare, group, &parent);
         if (!slot) {

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -64,10 +64,20 @@ static int nss_cache_node_compare(CRBTree *t, void *k, CRBNode *rb) {
 int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user) {
         NSSCacheNode *node;
         CRBNode **slot, *parent;
+        char *end;
+        unsigned long long int uid;
         int r;
 
         if (!strcmp(user, "root")) {
                 *uidp = 0;
+                return 0;
+        }
+
+        static_assert(sizeof(uid_t) == sizeof(uint32_t), "uid_t is not 32 bits");
+        errno = 0;
+        uid = strtoull(user, &end, 10);
+        if (end != user && *end == '\0' && errno == 0 && uid < UINT32_MAX) {
+                *uidp = uid;
                 return 0;
         }
 
@@ -96,10 +106,20 @@ int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user) {
 int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group) {
         NSSCacheNode *node;
         CRBNode **slot, *parent;
+        char *end;
+        unsigned long long int gid;
         int r;
 
         if (!strcmp(group, "root")) {
                 *gidp = 0;
+                return 0;
+        }
+
+        static_assert(sizeof(gid_t) == sizeof(uint32_t), "gid_t is not 32 bits");
+        errno = 0;
+        gid = strtoull(group, &end, 10);
+        if (end != group && *end == '\0' && errno == 0 && gid < UINT32_MAX) {
+                *gidp = gid;
                 return 0;
         }
 

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -1,0 +1,116 @@
+/*
+ * NSS Cache
+ */
+
+#include <c-macro.h>
+#include <c-rbtree.h>
+#include <grp.h>
+#include <pwd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include "launch/nss-cache.h"
+#include "util/error.h"
+
+typedef struct NSSCacheNode {
+        uint32_t uidgid;
+        CRBNode rb;
+        char name[];
+} NSSCacheNode;
+
+static int nss_cache_node_new(NSSCacheNode **nodep, const char *name, uint32_t uidgid) {
+        NSSCacheNode *node;
+        size_t n_name = strlen(name);
+
+        node = malloc(sizeof(*node) + n_name + 1);
+        if (!node)
+                return error_origin(-ENOMEM);
+        node->uidgid = uidgid;
+        node->rb = (CRBNode)C_RBNODE_INIT(node->rb);
+        memcpy(node->name, name, n_name + 1);
+
+        *nodep = node;
+        return 0;
+}
+
+static NSSCacheNode *nss_cache_node_free(NSSCacheNode *node) {
+        assert(!c_rbnode_is_linked(&node->rb));
+
+        free(node);
+
+        return NULL;
+}
+
+void nss_cache_init(NSSCache *cache) {
+        *cache = (NSSCache)NSS_CACHE_INIT;
+}
+
+void nss_cache_deinit(NSSCache *cache) {
+        NSSCacheNode *node, *_node;
+
+        c_rbtree_for_each_entry_safe_postorder_unlink(node, _node, &cache->user_tree, rb)
+                nss_cache_node_free(node);
+
+        c_rbtree_for_each_entry_safe_postorder_unlink(node, _node, &cache->group_tree, rb)
+                nss_cache_node_free(node);
+}
+
+static int nss_cache_node_compare(CRBTree *t, void *k, CRBNode *rb) {
+        const char *name = k;
+        NSSCacheNode *node = c_rbnode_entry(rb, NSSCacheNode, rb);
+
+        return strcmp(name, node->name);
+}
+
+int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user) {
+        NSSCacheNode *node;
+        CRBNode **slot, *parent;
+        int r;
+
+        slot = c_rbtree_find_slot(&cache->user_tree, nss_cache_node_compare, user, &parent);
+        if (!slot) {
+                node = c_rbnode_entry(parent, NSSCacheNode, rb);
+        } else {
+                struct passwd *pw;
+
+                pw = getpwnam(user);
+                if (!pw)
+                        return NSS_CACHE_E_INVALID_NAME;
+
+                r = nss_cache_node_new(&node, user, pw->pw_uid);
+                if (r)
+                        return error_trace(r);
+
+                c_rbtree_add(&cache->user_tree, parent, slot, &node->rb);
+        }
+
+        *uidp = node->uidgid;
+
+        return 0;
+}
+
+int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group) {
+        NSSCacheNode *node;
+        CRBNode **slot, *parent;
+        int r;
+
+        slot = c_rbtree_find_slot(&cache->group_tree, nss_cache_node_compare, group, &parent);
+        if (!slot) {
+                node = c_rbnode_entry(parent, NSSCacheNode, rb);
+        } else {
+                struct group *gr;
+
+                gr = getgrnam(group);
+                if (!gr)
+                        return NSS_CACHE_E_INVALID_NAME;
+
+                r = nss_cache_node_new(&node, group, gr->gr_gid);
+                if (r)
+                        return error_trace(r);
+
+                c_rbtree_add(&cache->group_tree, parent, slot, &node->rb);
+        }
+
+        *gidp = node->uidgid;
+
+        return 0;
+}

--- a/src/launch/nss-cache.h
+++ b/src/launch/nss-cache.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/*
+ * NSS Cache
+ */
+
+#include <c-macro.h>
+#include <c-rbtree.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+typedef struct NSSCache NSSCache;
+
+enum {
+        _NSS_CACHE_E_SUCCESS,
+
+        NSS_CACHE_E_INVALID_NAME,
+};
+
+struct NSSCache {
+        CRBTree user_tree;
+        CRBTree group_tree;
+};
+
+#define NSS_CACHE_INIT {                                                        \
+                .user_tree = C_RBTREE_INIT,                                     \
+                .group_tree = C_RBTREE_INIT,                                    \
+        }
+
+/* nss cache */
+
+void nss_cache_init(NSSCache *cache);
+void nss_cache_deinit(NSSCache *cache);
+
+int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user);
+int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group);

--- a/src/launch/test-config.c
+++ b/src/launch/test-config.c
@@ -6,6 +6,7 @@
 #include <c-macro.h>
 #include <stdlib.h>
 #include "launch/config.h"
+#include "launch/nss-cache.h"
 
 static const char *test_type2str[_CONFIG_NODE_N] = {
         [CONFIG_NODE_BUSCONFIG]         = "busconfig",
@@ -35,12 +36,13 @@ static const char *test_type2str[_CONFIG_NODE_N] = {
 static void print_config(const char *path) {
         _c_cleanup_(config_parser_deinit) ConfigParser parser = CONFIG_PARSER_NULL(parser);
         _c_cleanup_(config_root_freep) ConfigRoot *root = NULL;
+        _c_cleanup_(nss_cache_deinit) NSSCache nss_cache = NSS_CACHE_INIT;
         ConfigNode *i_node;
         int r;
 
         config_parser_init(&parser);
 
-        r = config_parser_read(&parser, &root, path);
+        r = config_parser_read(&parser, &root, path, &nss_cache);
         assert(!r);
 
         c_list_for_each_entry(i_node, &root->node_list, root_link) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -138,7 +138,7 @@ endif
 test_address = executable('test-address', ['dbus/test-address.c'], dependencies: libdbus_broker_dep)
 test('Address Handling', test_address)
 
-test_config = executable('test-config', ['launch/test-config.c', 'launch/config.c'], dependencies: libdbus_broker_dep)
+test_config = executable('test-config', ['launch/test-config.c', 'launch/config.c', 'launch/nss-cache.c'], dependencies: libdbus_broker_dep)
 test('Configuration Parser', test_config)
 
 test_dispatch = executable('test-dispatch', ['util/test-dispatch.c'], dependencies: libdbus_broker_dep)

--- a/src/meson.build
+++ b/src/meson.build
@@ -117,6 +117,7 @@ if use_launcher
                 [
                         'launch/config.c',
                         'launch/main.c',
+                        'launch/nss-cache.c',
                         'launch/policy.c',
                 ],
                 dependencies: [


### PR DESCRIPTION
The main feature of this PR is to use the correct UID when spawning transient units via systemd.

A few more nss fixes: we now cache the lookups, so we only resolve a user/group once during config/policy parsing. We immediately drop the cache though, so everything is re-resolved on reload.

We also now support user/group being the UID/GID directly, like the reference implementation always did. Lastly, we follow systemd and hard-code the "root" user/group to resolve to UID/GID 0 without going through NSS.