### PR TITLE
NameOwnerChanged subscriptions

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -19,6 +19,7 @@
 #include "util/dispatch.h"
 #include "util/error.h"
 #include "util/log.h"
+#include "util/proc.h"
 #include "util/user.h"
 
 static int broker_dispatch_signals(DispatchFile *file) {
@@ -87,6 +88,10 @@ int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_byt
         log_set_lossy(&broker->log, true);
 
         r = bus_init(&broker->bus, &broker->log, max_bytes, max_fds, max_matches, max_objects);
+        if (r)
+                return error_fold(r);
+
+        r = proc_get_seclabel(&broker->bus.seclabel, &broker->bus.n_seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include "broker/broker.h"
 #include "broker/controller.h"
 #include "bus/policy.h"
 #include "dbus/connection.h"
@@ -223,7 +224,7 @@ static int controller_method_add_listener(Controller *controller, const char *_p
         uint32_t fd_index;
         socklen_t n;
 
-        r = policy_registry_new(&policy, controller->seclabel);
+        r = policy_registry_new(&policy, controller->broker->bus.seclabel);
         if (r)
                 return error_fold(r);
 
@@ -319,7 +320,7 @@ static int controller_method_listener_set_policy(Controller *controller, const c
         ControllerListener *listener;
         int r;
 
-        r = policy_registry_new(&policy, controller->seclabel);
+        r = policy_registry_new(&policy, controller->broker->bus.seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -15,8 +15,6 @@
 #include "dbus/connection.h"
 #include "dbus/message.h"
 #include "util/error.h"
-#include "util/proc.h"
-#include "util/selinux.h"
 #include "util/sockopt.h"
 #include "util/user.h"
 
@@ -246,10 +244,6 @@ int controller_init(Controller *c, Broker *broker, int controller_fd) {
         *controller = (Controller)CONTROLLER_NULL(*controller);
         controller->broker = broker;
 
-        r = proc_get_seclabel(&controller->seclabel);
-        if (r)
-                return error_fold(r);
-
         r = connection_init_server(&controller->connection,
                                    &broker->dispatcher,
                                    controller_dispatch_connection,
@@ -277,7 +271,6 @@ void controller_deinit(Controller *controller) {
                 controller_listener_free(listener);
 
         connection_deinit(&controller->connection);
-        controller->seclabel = c_free(controller->seclabel);
         controller->broker = NULL;
 }
 

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -83,7 +83,6 @@ struct ControllerReload {
 
 struct Controller {
         Broker *broker;
-        char *seclabel;
         Connection connection;
         CRBTree name_tree;
         CRBTree listener_tree;

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -51,7 +51,7 @@ void bus_deinit(Bus *bus) {
         peer_registry_deinit(&bus->peers);
         user_registry_deinit(&bus->users);
         name_registry_deinit(&bus->names);
-        match_registry_deinit(&bus->driver_matches);
+        match_registry_deinit(&bus->sender_matches);
         match_registry_deinit(&bus->wildcard_matches);
 }
 

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -43,6 +43,8 @@ int bus_init(Bus *bus,
 }
 
 void bus_deinit(Bus *bus) {
+        bus->n_seclabel = 0;
+        bus->seclabel = c_free(bus->seclabel);
         bus->pid = 0;
         bus->user = user_unref(bus->user);
         metrics_deinit(&bus->metrics);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -29,6 +29,8 @@ struct Bus {
         Log *log;
         User *user;
         pid_t pid;
+        char *seclabel;
+        size_t n_seclabel;
         char guid[16];
 
         UserRegistry users;

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -36,7 +36,7 @@ struct Bus {
         UserRegistry users;
         NameRegistry names;
         MatchRegistry wildcard_matches;
-        MatchRegistry driver_matches;
+        MatchRegistry sender_matches;
         PeerRegistry peers;
 
         uint64_t transaction_ids;
@@ -49,7 +49,7 @@ struct Bus {
                 .users = USER_REGISTRY_NULL,                                    \
                 .names = NAME_REGISTRY_INIT,                                    \
                 .wildcard_matches = MATCH_REGISTRY_INIT((_x).wildcard_matches), \
-                .driver_matches = MATCH_REGISTRY_INIT((_x).driver_matches),     \
+                .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),     \
                 .peers = PEER_REGISTRY_INIT,                                    \
                 .metrics = METRICS_INIT,                                        \
         }

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -827,10 +827,6 @@ static int driver_method_request_name(Peer *peer, CDVar *in_v, uint32_t serial, 
 
         c_dvar_write(out_v, "(u)", reply);
 
-        r = driver_send_reply(peer, out_v, serial);
-        if (r)
-                return error_trace(r);
-
         if (change.name) {
                 r = driver_name_owner_changed(peer->bus,
                                               change.name->name,
@@ -846,6 +842,10 @@ static int driver_method_request_name(Peer *peer, CDVar *in_v, uint32_t serial, 
         }
 
         name_change_deinit(&change);
+
+        r = driver_send_reply(peer, out_v, serial);
+        if (r)
+                return error_trace(r);
 
         return 0;
 }
@@ -881,10 +881,6 @@ static int driver_method_release_name(Peer *peer, CDVar *in_v, uint32_t serial, 
 
         c_dvar_write(out_v, "(u)", reply);
 
-        r = driver_send_reply(peer, out_v, serial);
-        if (r)
-                return error_trace(r);
-
         if (change.name) {
                 r = driver_name_owner_changed(peer->bus,
                                               change.name->name,
@@ -895,6 +891,10 @@ static int driver_method_release_name(Peer *peer, CDVar *in_v, uint32_t serial, 
         }
 
         name_change_deinit(&change);
+
+        r = driver_send_reply(peer, out_v, serial);
+        if (r)
+                return error_trace(r);
 
         return 0;
 }

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1194,7 +1194,10 @@ static int driver_method_get_connection_unix_process_id(Peer *peer, CDVar *in_v,
 
 static int driver_method_get_connection_credentials(Peer *peer, CDVar *in_v, uint32_t serial, CDVar *out_v) {
         Peer *connection;
-        const char *name;
+        const char *name, *seclabel;
+        size_t n_seclabel;
+        uid_t uid;
+        pid_t pid;
         int r;
 
         c_dvar_read(in_v, "(s)", &name);
@@ -1203,15 +1206,27 @@ static int driver_method_get_connection_credentials(Peer *peer, CDVar *in_v, uin
         if (r)
                 return error_trace(r);
 
-        connection = bus_find_peer_by_name(peer->bus, NULL, name);
-        if (!connection)
-                return DRIVER_E_PEER_NOT_FOUND;
+        if (strcmp(name, "org.freedesktop.DBus") == 0) {
+                uid = peer->bus->user->uid;
+                pid = peer->bus->pid;
+                seclabel = peer->bus->seclabel;
+                n_seclabel = peer->bus->n_seclabel;
+        } else {
+                connection = bus_find_peer_by_name(peer->bus, NULL, name);
+                if (!connection)
+                        return DRIVER_E_PEER_NOT_FOUND;
+
+                uid = connection->user->uid;
+                pid = connection->pid;
+                seclabel = connection->seclabel;
+                n_seclabel = connection->n_seclabel;
+        }
 
         c_dvar_write(out_v, "([{s<u>}{s<u>}",
-                     "UnixUserID", c_dvar_type_u, connection->user->uid,
-                     "ProcessID", c_dvar_type_u, connection->pid);
+                     "UnixUserID", c_dvar_type_u, uid,
+                     "ProcessID", c_dvar_type_u, pid);
 
-        if (connection->n_seclabel) {
+        if (n_seclabel) {
                 /*
                  * The DBus specification says that the security-label is a
                  * byte array of non-0 values. The kernel disagrees.
@@ -1223,7 +1238,7 @@ static int driver_method_get_connection_credentials(Peer *peer, CDVar *in_v, uin
                  * so we can safely copy from it.
                  */
                 c_dvar_write(out_v, "{s<", "LinuxSecurityLabel", (const CDVarType[]){ C_DVAR_T_INIT(C_DVAR_T_ARRAY(C_DVAR_T_y)) });
-                driver_write_bytes(out_v, connection->seclabel, connection->n_seclabel + 1);
+                driver_write_bytes(out_v, seclabel, n_seclabel + 1);
                 c_dvar_write(out_v, ">}");
         }
 

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1788,7 +1788,7 @@ int driver_goodbye(Peer *peer, bool silent) {
                 peer_unregister(peer);
         }
 
-        c_rbtree_for_each_entry_safe_postorder_unlink(reply, reply_safe, &peer->replies_outgoing.reply_tree, registry_node) {
+        c_rbtree_for_each_entry_safe_postorder_unlink(reply, reply_safe, &peer->replies.reply_tree, registry_node) {
                 Peer *sender = c_container_of(reply->owner, Peer, owned_replies);
 
                 if (!silent) {

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -65,5 +65,4 @@ int driver_name_activation_failed(Bus *bus, Activation *activation);
 int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 
 int driver_dispatch(Peer *peer, Message *message);
-void driver_matches_cleanup(MatchOwner *owner, Bus *bus, User *user);
 int driver_goodbye(Peer *peer, bool silent);

--- a/src/bus/name.c
+++ b/src/bus/name.c
@@ -227,7 +227,7 @@ void name_free(_Atomic unsigned long *n_refs, void *userdata) {
         assert(c_list_is_empty(&name->ownership_list));
         assert(!name->activation);
 
-        match_registry_deinit(&name->matches);
+        match_registry_deinit(&name->sender_matches);
         c_rbnode_unlink(&name->registry_node);
         free(name);
 }

--- a/src/bus/name.c
+++ b/src/bus/name.c
@@ -227,6 +227,7 @@ void name_free(_Atomic unsigned long *n_refs, void *userdata) {
         assert(c_list_is_empty(&name->ownership_list));
         assert(!name->activation);
 
+        match_registry_deinit(&name->name_owner_changed_matches);
         match_registry_deinit(&name->sender_matches);
         c_rbnode_unlink(&name->registry_node);
         free(name);

--- a/src/bus/name.h
+++ b/src/bus/name.h
@@ -61,16 +61,18 @@ struct Name {
 
         Activation *activation;
         MatchRegistry sender_matches;
+        MatchRegistry name_owner_changed_matches;
 
         CList ownership_list;
         char name[];
 };
 
-#define NAME_INIT(_x) {                                                         \
-                .n_refs = C_REF_INIT,                                           \
-                .registry_node = C_RBNODE_INIT((_x).registry_node),             \
-                .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),     \
-                .ownership_list = C_LIST_INIT((_x).ownership_list),             \
+#define NAME_INIT(_x) {                                                                                 \
+                .n_refs = C_REF_INIT,                                                                   \
+                .registry_node = C_RBNODE_INIT((_x).registry_node),                                     \
+                .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),                             \
+                .name_owner_changed_matches = MATCH_REGISTRY_INIT((_x).name_owner_changed_matches),     \
+                .ownership_list = C_LIST_INIT((_x).ownership_list),                                     \
         }
 
 struct NameOwner {

--- a/src/bus/name.h
+++ b/src/bus/name.h
@@ -60,7 +60,7 @@ struct Name {
         CRBNode registry_node;
 
         Activation *activation;
-        MatchRegistry matches;
+        MatchRegistry sender_matches;
 
         CList ownership_list;
         char name[];
@@ -69,7 +69,7 @@ struct Name {
 #define NAME_INIT(_x) {                                                         \
                 .n_refs = C_REF_INIT,                                           \
                 .registry_node = C_RBNODE_INIT((_x).registry_node),             \
-                .matches = MATCH_REGISTRY_INIT((_x).matches),                   \
+                .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),     \
                 .ownership_list = C_LIST_INIT((_x).ownership_list),             \
         }
 

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -24,7 +24,6 @@
 #include "util/fdlist.h"
 #include "util/log.h"
 #include "util/metrics.h"
-#include "util/selinux.h"
 #include "util/sockopt.h"
 #include "util/user.h"
 

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -72,7 +72,7 @@ struct Peer {
         NameOwner owned_names;
         MatchRegistry matches;
         MatchOwner owned_matches;
-        ReplyRegistry replies_outgoing;
+        ReplyRegistry replies;
         ReplyOwner owned_replies;
 
         uint64_t transaction_id;

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -70,7 +70,7 @@ struct Peer {
 
         PolicySnapshot *policy;
         NameOwner owned_names;
-        MatchRegistry matches;
+        MatchRegistry sender_matches;
         MatchOwner owned_matches;
         ReplyRegistry replies;
         ReplyOwner owned_replies;

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -71,12 +71,28 @@ struct Peer {
         PolicySnapshot *policy;
         NameOwner owned_names;
         MatchRegistry sender_matches;
+        MatchRegistry name_owner_changed_matches;
         MatchOwner owned_matches;
         ReplyRegistry replies;
         ReplyOwner owned_replies;
 
         uint64_t transaction_id;
 };
+
+#define PEER_INIT(_x) {                                                                                 \
+                .charges[0] = USER_CHARGE_INIT,                                                         \
+                .charges[1] = USER_CHARGE_INIT,                                                         \
+                .charges[2] = USER_CHARGE_INIT,                                                         \
+                .registry_node = C_RBNODE_INIT((_x).registry_node),                                     \
+                .listener_link = C_LIST_INIT((_x).listener_link),                                       \
+                .connection = CONNECTION_NULL((_x).connection),                                         \
+                .owned_names = NAME_OWNER_INIT,                                                         \
+                .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),                             \
+                .name_owner_changed_matches = MATCH_REGISTRY_INIT((_x).name_owner_changed_matches),     \
+                .owned_matches = MATCH_OWNER_INIT,                                                      \
+                .replies = REPLY_REGISTRY_INIT,                                                         \
+                .owned_replies = REPLY_OWNER_INIT((_x).owned_replies),                                  \
+        }
 
 struct PeerRegistry {
         CRBTree peer_tree;
@@ -107,7 +123,7 @@ void peer_flush_matches(Peer *peer);
 
 int peer_queue_call(PolicySnapshot *sender_policy, NameSet *sender_names, MatchRegistry *sender_matches, ReplyOwner *sender_replies, User *sender_user, uint64_t sender_id, Peer *receiver, Message *message);
 int peer_queue_reply(Peer *sender, const char *destination, uint32_t reply_serial, Message *message);
-int peer_broadcast(PolicySnapshot *sender_policy, NameSet *sender_names, MatchRegistry *sender_matches, uint64_t sender_id, Peer *destination, Bus *bus, MatchFilter *filter, Message *message);
+int peer_broadcast(PolicySnapshot *sender_policy, NameSet *sender_names, MatchRegistry *matches, uint64_t sender_id, Peer *destination, Bus *bus, MatchFilter *filter, Message *message);
 
 void peer_registry_init(PeerRegistry *registry);
 void peer_registry_deinit(PeerRegistry *registry);

--- a/src/util/proc.c
+++ b/src/util/proc.c
@@ -12,7 +12,7 @@
  * XXX: The kernel should be made to handle SO_PEERSEC also on
  *      socketpair sockets, making this redundant.
  */
-int proc_get_seclabel(char **labelp) {
+int proc_get_seclabel(char **labelp, size_t *n_labelp) {
         _c_cleanup_(c_fclosep) FILE *f = NULL;
         char buffer[LINE_MAX] = {}, *c, *label;
 
@@ -32,6 +32,8 @@ int proc_get_seclabel(char **labelp) {
         if (!label)
                 return error_origin(-ENOMEM);
 
+        if (n_labelp)
+                *n_labelp = strlen(label);
         *labelp = label;
         return 0;
 }

--- a/src/util/proc.h
+++ b/src/util/proc.h
@@ -7,4 +7,4 @@
 #include <c-macro.h>
 #include <stdlib.h>
 
-int proc_get_seclabel(char **labelp);
+int proc_get_seclabel(char **labelp, size_t *n_labelp);

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -15,6 +15,7 @@ libtest_private = static_library(
                 dep_csundry,
                 dep_libsystemd,
                 dep_thread,
+                libdbus_broker_dep,
         ],
         pic: true,
 )
@@ -44,10 +45,14 @@ test('Driver API', test_driver)
 test_fdstream = executable('test-fdstream', ['test-fdstream.c'], dependencies: [ libtest_dep ])
 test('FD Stream Constraints', test_fdstream)
 
+test_lifetime = executable('test-lifetime', ['test-lifetime.c'], dependencies: [ libtest_dep ])
+test('Client Lifetime', test_lifetime)
+
 if use_reference_test
         dbus_bin = dep_dbus.get_pkgconfig_variable('bindir') + '/dbus-daemon'
 
         test('dbus-daemon(1): Broker API', test_broker, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
         test('dbus-daemon(1): Driver API', test_driver, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
         test('dbus-daemon(1): FD Stream Constraints', test_fdstream, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('dbus-daemon(1): Client Lifetime', test_lifetime, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
 endif

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -48,6 +48,9 @@ test('FD Stream Constraints', test_fdstream)
 test_lifetime = executable('test-lifetime', ['test-lifetime.c'], dependencies: [ libtest_dep ])
 test('Client Lifetime', test_lifetime)
 
+test_matches = executable('test-matches', ['test-matches.c'], dependencies: [ libtest_dep ])
+test('Signals and Matches', test_matches)
+
 if use_reference_test
         dbus_bin = dep_dbus.get_pkgconfig_variable('bindir') + '/dbus-daemon'
 
@@ -55,4 +58,5 @@ if use_reference_test
         test('dbus-daemon(1): Driver API', test_driver, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
         test('dbus-daemon(1): FD Stream Constraints', test_fdstream, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
         test('dbus-daemon(1): Client Lifetime', test_lifetime, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('dbus-daemon(1): Signals and Matches', test_matches, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
 endif

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -568,7 +568,8 @@ static void test_name_has_owner(void) {
         {
                 _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
                 _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-                const char *unique_name, *owned;
+                const char *unique_name;
+                int owned;
 
                 util_broker_connect(broker, &bus);
 
@@ -588,7 +589,7 @@ static void test_name_has_owner(void) {
         {
                 _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
                 _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-                const char *owned;
+                int owned;
 
                 util_broker_connect(broker, &bus);
 
@@ -615,7 +616,7 @@ static void test_name_has_owner(void) {
         {
                 _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
                 _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
-                const char *owned;
+                int owned;
 
                 util_broker_connect(broker, &bus);
 

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -725,6 +725,27 @@ static void test_start_service_by_name(void) {
         util_broker_terminate(broker);
 }
 
+static void test_update_activation_environment(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+
+                util_broker_connect(broker, &bus);
+
+                r = sd_bus_call_method(bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "UpdateActivationEnvironment", NULL, NULL,
+                                       "a{ss}", 1, "foo", "bar");
+                assert(r >= 0);
+        }
+
+        util_broker_terminate(broker);
+}
+
 static void test_list_names(void) {
         _c_cleanup_(util_broker_freep) Broker *broker = NULL;
         int r;
@@ -1816,6 +1837,7 @@ int main(int argc, char **argv) {
         test_get_name_owner();
         test_name_has_owner();
         test_start_service_by_name();
+        test_update_activation_environment();
         test_list_names();
         test_list_activatable_names();
         test_add_match();
@@ -1833,12 +1855,3 @@ int main(int argc, char **argv) {
 
         return 0;
 }
-
-#if 0
-static void test_driver_api(struct sockaddr_un *address, socklen_t addrlen) {
-        r = sd_bus_call_method(bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
-                               "UpdateActivationEnvironment", NULL, NULL,
-                               "a{ss}", 0);
-        assert(r >= 0);
-}
-#endif

--- a/test/dbus/test-lifetime.c
+++ b/test/dbus/test-lifetime.c
@@ -1,0 +1,147 @@
+/*
+ * Client Lifetime Tests
+ */
+
+#include <c-macro.h>
+#include <stdlib.h>
+#include "util-broker.h"
+
+static void test_dummy(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *monitor = NULL;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect_monitor(broker, &monitor);
+        util_broker_terminate(broker);
+}
+
+static void test_client(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *monitor = NULL;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect_monitor(broker, &monitor);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+
+                util_broker_connect(broker, &bus);
+        }
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "Hello");
+        util_broker_consume_method_return(monitor);
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_monitor(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *monitor = NULL;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect_monitor(broker, &monitor);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+
+                util_broker_connect_monitor(broker, &bus);
+        }
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "Hello");
+        util_broker_consume_method_return(monitor);
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus.Monitoring", "BecomeMonitor");
+        util_broker_consume_method_return(monitor);
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_names(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *monitor = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect_monitor(broker, &monitor);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus1 = NULL;
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus2 = NULL;
+
+                util_broker_connect(broker, &bus1);
+
+                r = sd_bus_call_method(bus1, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "RequestName", NULL, NULL,
+                                       "su", "com.example.foo", 0);
+                assert(r >= 0);
+
+                util_broker_connect(broker, &bus2);
+
+                r = sd_bus_call_method(bus2, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "RequestName", NULL, NULL,
+                                       "su", "com.example.foo", 0);
+                assert(r >= 0);
+
+                r = sd_bus_call_method(bus1, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "ReleaseName", NULL, NULL,
+                                       "s", "com.example.foo");
+                assert(r >= 0);
+        }
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "Hello");
+        util_broker_consume_method_return(monitor);
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "RequestName");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+        util_broker_consume_method_return(monitor);
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "Hello");
+        util_broker_consume_method_return(monitor);
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "RequestName");
+        util_broker_consume_method_return(monitor);
+
+        util_broker_consume_method_call(monitor, "org.freedesktop.DBus", "ReleaseName");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameAcquired");
+        util_broker_consume_method_return(monitor);
+
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameLost");
+        util_broker_consume_signal(monitor, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+int main(int argc, char **argv) {
+        test_dummy();
+        test_client();
+        test_monitor();
+        test_names();
+}

--- a/test/dbus/test-matches.c
+++ b/test/dbus/test-matches.c
@@ -1,0 +1,269 @@
+/*
+ * Client Lifetime Tests
+ */
+
+#include <c-macro.h>
+#include <stdlib.h>
+#include "util-broker.h"
+
+static void test_wildcard(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *sender = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &sender);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "");
+        assert(r >= 0);
+
+        r = sd_bus_emit_signal(sender, "/org/example", "org.example", "Foo", "");
+        assert(r >= 0);
+
+        util_broker_consume_signal(receiver, "org.example", "Foo");
+
+        util_broker_terminate(broker);
+}
+
+static void test_unique_name(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *sender = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        _c_cleanup_(c_freep) char *match = NULL;
+        const char *unique_name;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &sender);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_get_unique_name(sender, &unique_name);
+        assert(r >= 0);
+
+        r = asprintf(&match, "sender=%s", unique_name);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", match);
+        assert(r >= 0);
+
+        r = sd_bus_emit_signal(sender, "/org/example", "org.example", "Foo", "");
+        assert(r >= 0);
+
+        util_broker_consume_signal(receiver, "org.example", "Foo");
+
+        util_broker_terminate(broker);
+}
+
+static void test_well_known_name(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *dummy = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *sender = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &dummy);
+        util_broker_connect(broker, &sender);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(dummy, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "RequestName", NULL, NULL,
+                               "su", "com.example.foo", 0);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(sender, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "RequestName", NULL, NULL,
+                               "su", "com.example.foo", 0);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(sender, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "RequestName", NULL, NULL,
+                               "su", "com.example.bar", 0);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=com.example.foo");
+        assert(r >= 0);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=com.example.bar,interface=org.example.bar");
+        assert(r >= 0);
+
+        r = sd_bus_emit_signal(sender, "/org/example", "org.example", "Foo", "");
+        assert(r >= 0);
+
+        r = sd_bus_emit_signal(sender, "/org/example", "org.example.bar", "Bar", "");
+        assert(r >= 0);
+
+        util_broker_consume_signal(receiver, "org.example.bar", "Bar");
+
+        util_broker_terminate(broker);
+}
+
+static void test_driver(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=org.freedesktop.DBus");
+        assert(r >= 0);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *dummy = NULL;
+
+                util_broker_connect(broker, &dummy);
+        }
+
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_noc_wildcard(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=org.freedesktop.DBus,member=NameOwnerChanged");
+        assert(r >= 0);
+
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *dummy = NULL;
+
+                util_broker_connect(broker, &dummy);
+        }
+
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_noc_unique(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        sd_bus *dummy; /* explicitly cleaned up below */
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        _c_cleanup_(c_freep) char *match = NULL;
+        const char *unique_name;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &dummy);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_get_unique_name(dummy, &unique_name);
+        assert(r >= 0);
+
+        r = asprintf(&match, "sender=org.freedesktop.DBus,member=NameOwnerChanged,arg0=%s", unique_name);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", match);
+        assert(r >= 0);
+
+        sd_bus_flush_close_unref(dummy);
+
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_noc_well_known(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *dummy = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &dummy);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=org.freedesktop.DBus,member=NameOwnerChanged,arg0=com.example.foo");
+        assert(r >= 0);
+
+        r = sd_bus_call_method(dummy, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "RequestName", NULL, NULL,
+                               "su", "com.example.foo", 0);
+        assert(r >= 0);
+
+        r = sd_bus_call_method(dummy, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "ReleaseName", NULL, NULL,
+                               "s", "com.example.foo");
+        assert(r >= 0);
+
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+        util_broker_consume_signal(receiver, "org.freedesktop.DBus", "NameOwnerChanged");
+
+        util_broker_terminate(broker);
+}
+
+static void test_noc_driver(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *dummy = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *receiver = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        util_broker_connect(broker, &dummy);
+        util_broker_connect(broker, &receiver);
+
+        r = sd_bus_call_method(receiver, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "AddMatch", NULL, NULL,
+                               "s", "sender=org.freedesktop.DBus,member=NameOwnerChanged,arg0=org.freedesktop.DBus");
+        assert(r >= 0);
+
+        /*
+         * This cannot be triggered, but make sure the implementation does not choke on this
+         * special name.
+         */
+        util_broker_terminate(broker);
+}
+
+int main(int argc, char **argv) {
+        test_wildcard();
+        test_unique_name();
+        test_well_known_name();
+        test_driver();
+        test_noc_wildcard();
+        test_noc_unique();
+        test_noc_well_known();
+        test_noc_driver();
+}

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -32,8 +32,16 @@ void util_event_new(sd_event **eventp) {
 }
 
 static int util_event_sigchld(sd_event_source *source, const siginfo_t *si, void *userdata) {
-        return sd_event_exit(sd_event_source_get_event(source),
-                             (si->si_code == CLD_EXITED) ? si->si_status : EXIT_FAILURE);
+        int status;
+
+        if (si->si_code == CLD_EXITED)
+                status = si->si_status;
+        else if (si->si_code == CLD_KILLED && si->si_status == SIGTERM)
+                status = EXIT_SUCCESS;
+        else
+                status = EXIT_FAILURE;
+
+        return sd_event_exit(sd_event_source_get_event(source), status);
 }
 
 #define POLICY_T_BATCH                                                          \

--- a/test/dbus/util-broker.h
+++ b/test/dbus/util-broker.h
@@ -49,5 +49,11 @@ void util_broker_terminate(Broker *broker);
 void util_broker_connect_fd(Broker *broker, int *fdp);
 void util_broker_connect_raw(Broker *broker, sd_bus **busp);
 void util_broker_connect(Broker *broker, sd_bus **busp);
+void util_broker_connect_monitor(Broker *broker, sd_bus **busp);
+
+void util_broker_consume_method_call(sd_bus *bus, const char *interface, const char *member);
+void util_broker_consume_method_return(sd_bus *bus);
+void util_broker_consume_method_error(sd_bus *bus, const char *name);
+void util_broker_consume_signal(sd_bus *bus, const char *interface, const char *member);
 
 C_DEFINE_CLEANUP(Broker *, util_broker_free);


### PR DESCRIPTION
Make NameOwnerChanged matches work like subscriptions on the name in question, rather than driver-wide matches. This should greatly improve the scalability of a common use-case.

This is just a proof-of-concept, compile-tested only to show the idea.