### PR TITLE
test/util-broker/spawn: add a barrier before returning

### DIFF
--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -30,7 +30,7 @@ static void test_hello(void) {
 
                 r = sd_bus_message_read(reply, "s", &unique_name);
                 assert(r >= 0);
-                assert(!strcmp(unique_name, ":1.0"));
+                assert(!strcmp(unique_name, ":1.1"));
 
                 /* calling Hello() again is not valid */
                 r = sd_bus_call_method(bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",

--- a/test/dbus/test-fdstream.c
+++ b/test/dbus/test-fdstream.c
@@ -59,7 +59,7 @@ static void test_fd_stream_send(Connection *c, unsigned int unix_fds, unsigned i
                      DBUS_MESSAGE_TYPE_METHOD_CALL,
                      DBUS_HEADER_FLAG_NO_REPLY_EXPECTED,
                      1, 0, ++test_fd_stream_seq,
-                     DBUS_MESSAGE_FIELD_DESTINATION, c_dvar_type_s, ":1.0",
+                     DBUS_MESSAGE_FIELD_DESTINATION, c_dvar_type_s, ":1.1",
                      DBUS_MESSAGE_FIELD_PATH, c_dvar_type_o, "/",
                      DBUS_MESSAGE_FIELD_MEMBER, c_dvar_type_s, "Foobar",
                      DBUS_MESSAGE_FIELD_UNIX_FDS, c_dvar_type_u, unix_fds);
@@ -151,7 +151,7 @@ static int test_fd_stream_fn(DispatchFile *file) {
 
                         if (m->metadata.fields.reply_serial == 1) {
 
-                                assert(!strcmp(m->metadata.args[0].value, ":1.0"));
+                                assert(!strcmp(m->metadata.args[0].value, ":1.1"));
                                 assert(!m->metadata.fields.unix_fds);
                                 ++test_fd_stream_got;
 

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -174,7 +174,6 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
 
                 r = execl("./src/dbus-broker",
                           "./src/dbus-broker",
-                          "--verbose",
                           "--controller", fdstr,
                           (char *)NULL);
                 /* execl(2) only returns on error */
@@ -313,6 +312,7 @@ Broker *util_broker_free(Broker *broker) {
         if (!broker)
                 return NULL;
 
+        assert(!broker->client);
         assert(broker->listener_fd < 0);
         assert(broker->pipe_fds[0] < 0);
         assert(broker->pipe_fds[1] < 0);
@@ -464,6 +464,16 @@ void util_broker_spawn(Broker *broker) {
         assert(!r);
 
         pthread_sigmask(SIG_SETMASK, &sigold, NULL);
+
+        /*
+         * Do a barrier, by calling a method on the driver to make sure it is fully up
+         * and running.
+         */
+        util_broker_connect(broker, &broker->client);
+
+        r = sd_bus_call_method(broker->client, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                               "GetId", NULL, NULL, "");
+        assert(r >= 0);
 }
 
 void util_broker_terminate(Broker *broker) {
@@ -471,6 +481,8 @@ void util_broker_terminate(Broker *broker) {
         int r;
 
         assert(broker->listener_fd >= 0 || broker->pipe_fds[0] >= 0);
+
+        broker->client = sd_bus_unref(broker->client);
 
         r = pthread_kill(broker->thread, SIGUSR1);
         assert(!r);

--- a/test/dbus/util-broker.h
+++ b/test/dbus/util-broker.h
@@ -23,6 +23,7 @@ struct Broker {
         int pipe_fds[2];
         pid_t pid;
         pid_t child_pid;
+        sd_bus *client;
 };
 
 #define BROKER_NULL {                                                           \


### PR DESCRIPTION
Make sure the broker/daemon is fully operational by the time spawn() returns. Without
this the setup of the broker could still be happening when we start the performance
measurements.

Signed-off-by: Tom Gundersen <teg@jklm.no>