### PR TITLE
launch/policy: improve warnings

### DIFF
--- a/src/bus/policy.c
+++ b/src/bus/policy.c
@@ -450,15 +450,14 @@ static int policy_registry_import_batch(PolicyRegistry *registry,
         c_dvar_read(v, "][");
 
         while (c_dvar_more(v)) {
-                c_dvar_read(v, "(btssssub)",
+                c_dvar_read(v, "(btssssu)",
                             &verdict.verdict,
                             &verdict.priority,
                             &name_str,
                             &path,
                             &interface,
                             &member,
-                            &type,
-                            NULL);
+                            &type);
 
                 r = policy_batch_add_send(batch,
                                           name_str,
@@ -474,15 +473,14 @@ static int policy_registry_import_batch(PolicyRegistry *registry,
         c_dvar_read(v, "][");
 
         while (c_dvar_more(v)) {
-                c_dvar_read(v, "(btssssub)",
+                c_dvar_read(v, "(btssssu)",
                             &verdict.verdict,
                             &verdict.priority,
                             &name_str,
                             &path,
                             &interface,
                             &member,
-                            &type,
-                            NULL);
+                            &type);
 
                 r = policy_batch_add_recv(batch,
                                           name_str,

--- a/src/dbus/message.c
+++ b/src/dbus/message.c
@@ -432,8 +432,7 @@ int message_parse_metadata(Message *message) {
         /*
          * Now that the header is validated, we read through the message body.
          * Again, this is required for compatibility with dbus-daemon(1), but
-         * also to fetch the arguments for match-filters used by eavesdropping
-         * and common broadcasts.
+         * also to fetch the arguments for match-filters used by broadcasts.
          */
         r = message_parse_body(message, &message->metadata);
         if (r)

--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -450,16 +450,18 @@ static int policy_import_send(Policy *policy, ConfigNode *cnode) {
         }
 
         if (cnode->allow_deny.send_type == DBUS_MESSAGE_TYPE_METHOD_RETURN ||
-            cnode->allow_deny.send_type == DBUS_MESSAGE_TYPE_ERROR) {
-                fprintf(stderr, "Reply/Error policy in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
-                        cnode->file, cnode->lineno);
-                return 0;
-        }
+            cnode->allow_deny.send_type == DBUS_MESSAGE_TYPE_ERROR ||
+            cnode->allow_deny.send_type == DBUS_MESSAGE_TYPE_INVALID) {
+                if (cnode->type == CONFIG_NODE_DENY && cnode->allow_deny.send_requested_reply == CONFIG_TRISTATE_YES)
+                        fprintf(stderr, "Policy to deny expected replies in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
+                                cnode->file, cnode->lineno);
+                else if (cnode->type == CONFIG_NODE_ALLOW && cnode->allow_deny.send_requested_reply == CONFIG_TRISTATE_NO)
+                        fprintf(stderr, "Policy to allow unexpected replies in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
+                                cnode->file, cnode->lineno);
 
-        if (cnode->allow_deny.send_error ||
-            cnode->allow_deny.send_requested_reply)
-                fprintf(stderr, "Expected-reply/Error policy match in %s +%lu: Those attributes are deprecated and ignored\n",
-                        cnode->file, cnode->lineno);
+                if (cnode->allow_deny.send_type != DBUS_MESSAGE_TYPE_INVALID)
+                        return 0;
+        }
 
         r = policy_record_new_xmit(&record);
         if (r)
@@ -532,16 +534,18 @@ static int policy_import_recv(Policy *policy, ConfigNode *cnode) {
         }
 
         if (cnode->allow_deny.recv_type == DBUS_MESSAGE_TYPE_METHOD_RETURN ||
-            cnode->allow_deny.recv_type == DBUS_MESSAGE_TYPE_ERROR) {
-                fprintf(stderr, "Reply/Error policy in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
-                        cnode->file, cnode->lineno);
-                return 0;
-        }
+            cnode->allow_deny.recv_type == DBUS_MESSAGE_TYPE_ERROR ||
+            cnode->allow_deny.recv_type == DBUS_MESSAGE_TYPE_INVALID) {
+                if (cnode->type == CONFIG_NODE_DENY && cnode->allow_deny.recv_requested_reply == CONFIG_TRISTATE_YES)
+                        fprintf(stderr, "Policy to deny expected replies in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
+                                cnode->file, cnode->lineno);
+                else if (cnode->type == CONFIG_NODE_ALLOW && cnode->allow_deny.recv_requested_reply == CONFIG_TRISTATE_NO)
+                        fprintf(stderr, "Policy to allow unexpected replies in %s +%lu: Explicit policies on replies and errors are deprecated and ignored\n",
+                                cnode->file, cnode->lineno);
 
-        if (cnode->allow_deny.recv_error ||
-            cnode->allow_deny.recv_requested_reply)
-                fprintf(stderr, "Expected-reply/Error policy match in %s +%lu: Those attributes are deprecated and ignored\n",
-                        cnode->file, cnode->lineno);
+                if (cnode->allow_deny.recv_type != DBUS_MESSAGE_TYPE_INVALID)
+                        return 0;
+        }
 
         r = policy_record_new_xmit(&record);
         if (r)

--- a/src/launch/policy.h
+++ b/src/launch/policy.h
@@ -34,7 +34,6 @@ struct PolicyRecord {
                         const char *interface;
                         const char *member;
                         unsigned int type;
-                        bool eavesdrop;
                 } xmit;
 
                 struct {

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -48,8 +48,8 @@ static int util_event_sigchld(sd_event_source *source, const siginfo_t *si, void
 #define POLICY_T_BATCH                                                          \
                 "bt"                                                            \
                 "a(btbs)"                                                       \
-                "a(btssssub)"                                                   \
-                "a(btssssub)"
+                "a(btssssu)"                                                   \
+                "a(btssssu)"
 
 #define POLICY_T                                                                \
                 "(" POLICY_T_BATCH ")"                                          \
@@ -79,11 +79,11 @@ static int util_append_policy(sd_bus_message *m) {
                  *  - allow all recvs
                  */
                 r = sd_bus_message_append(m,
-                                          "bt" "a(btbs)" "a(btssssub)" "a(btssssub)",
+                                          "bt" "a(btbs)" "a(btssssu)" "a(btssssu)",
                                           true, UINT64_C(1),
                                           1, true, UINT64_C(1), true, "",
-                                          1, true, UINT64_C(1), "", "", "", "", 0, false,
-                                          1, true, UINT64_C(1), "", "", "", "", 0, false);
+                                          1, true, UINT64_C(1), "", "", "", "", 0,
+                                          1, true, UINT64_C(1), "", "", "", "", 0);
 
                 r = sd_bus_message_close_container(m);
                 assert(r >= 0);


### PR DESCRIPTION
Improve warnings emitted by the launcher on deprecated policy. Make sure we always log when ignoring policy that is not a noop, but do not log about ignoring policy that would not have any effect.

This also fixes an (obscure) bug related to eavesdrop policies.