### PR TITLE
launch/config: Make correct path for included file

### DIFF
--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -6,6 +6,7 @@
 #include <c-macro.h>
 #include <expat.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include "dbus/protocol.h"
 #include "launch/config.h"
 #include "launch/nss-cache.h"
@@ -38,7 +39,15 @@ int config_path_new(ConfigPath **filep, ConfigPath *parent, const char *prefix, 
         /* prepend parent-path if @path is relative */
         if (path[0] != '/') {
                 if (prefix) {
-                        n_prefix = strlen(prefix);
+			n_prefix = strlen(prefix);
+			struct stat st;
+			stat(prefix, &st);
+			if (!S_ISDIR(st.st_mode)) {
+                                t = strrchr(prefix, '/');
+                                if (t) {
+                                        n_prefix = t - prefix;
+                                }
+                        }
                 } else if (parent) {
                         if (parent->is_dir) {
                                 prefix = parent->path;


### PR DESCRIPTION
When config file has a include node with relative path(e.g. <include>
some.conf</include>), it makes a wrong path. The included file path
should be in the same directory as config file(denoted as prefix).

Therefore add codes to judge whether prefix is a file or directory here.
If prefix is a directory, included file's name is added after prefix.
If prefix is a file, config file's name is replaced by included file's
name. So that it can create correct path for included file.