### PR TITLE
launch/config: fix path computation for <include>

### DIFF
--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -1022,7 +1022,7 @@ static void config_parser_end_fn(void *userdata, const XML_Char *name) {
                                     state->file,
                                     state->current->include.selinux_root_relative ?
                                         bus_selinux_policy_root() :
-                                        state->file->path,
+                                        NULL,
                                     state->current->cdata);
                 if (r) {
                         state->error = error_trace(r);


### PR DESCRIPTION
This is a shorter fix for #98, supposed to fix #96. I tested it locally, and it works as expected.

@ylse: If you provide a `Reviewed-by: Name [<email>]` line, I can append it to the patch.