### PR TITLE
build: make documentation optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,8 +24,6 @@ mod_pkgconfig = import('pkgconfig')
 # Mandatory Dependencies
 #
 
-prog_rst2man = find_program('rst2man', 'rst2man.py')
-
 sub_cdvar = subproject('c-dvar', version: '>=1')
 sub_clist = subproject('c-list', version: '>=3')
 sub_crbtree = subproject('c-rbtree', version: '>=3')
@@ -45,6 +43,15 @@ dep_thread = dependency('threads')
 use_audit = get_option('audit')
 if use_audit
         dep_libaudit = dependency('audit', version: '>=2.7')
+endif
+
+#
+# Config: docs
+#
+
+use_docs = get_option('docs')
+if use_docs
+        prog_rst2man = find_program('rst2man', 'rst2man.py')
 endif
 
 #
@@ -102,8 +109,11 @@ conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 # Subdirs
 #
 
-subdir('docs')
 subdir('src')
+
+if use_docs
+        subdir('docs')
+endif
 
 if use_launcher
         subdir('test/dbus')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('audit', type: 'boolean', value: false, description: 'Audit support')
 option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
+option('docs', type: 'boolean', value: false, description: 'Build documentation')
 option('reference-test', type: 'boolean', value: false, description: 'Run test suite against reference implementation')
 option('selinux', type: 'boolean', value: false, description: 'SELinux support')
 option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')


### PR DESCRIPTION
Make building documentation opt-in.

See: <http://lists.openembedded.org/pipermail/openembedded-devel/2018-March/117419.html>.