### PR TITLE
Fix typos

### DIFF
--- a/docs/dbus-broker-launch.rst
+++ b/docs/dbus-broker-launch.rst
@@ -23,7 +23,7 @@ DESCRIPTION
 
 dbus-broker-launch provides a drop-in replacement for the functionality of dbus-daemon(1). It
 installs a listening socket, or takes one passed in, and it parses the relevant configuration
-files. It forks off and controlls an instance of dbus-broker\(1), which implements the actual
+files. It forks off and controls an instance of dbus-broker\(1), which implements the actual
 message bus.
 
 OPTIONS

--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -122,7 +122,7 @@ int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t gid, gid_t **gidsp
                 if (!warned) {
                         warned = true;
                         log_append_here(log, LOG_ERR, 0);
-                        log_commitf(log, "Falling back to resolving auxillary "
+                        log_commitf(log, "Falling back to resolving auxiliary "
                                          "groups using nss, this is racy and "
                                          "may cause deadlocks. Update to a "
                                          "kernel with SO_PEERGROUPS "


### PR DESCRIPTION
Just two typos spotted by `lintian` in the Debian package.