### PR TITLE
Avoid NSS lookups

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -1267,7 +1267,7 @@ static int manager_set_policy(Manager *manager, Policy *policy, uint32_t *system
 static int manager_reload_config(Manager *manager) {
         _c_cleanup_(config_root_freep) ConfigRoot *root = NULL;
         _c_cleanup_(policy_deinit) Policy policy = POLICY_INIT(policy);
-        _c_cleanup_(nss_cache_deinit) NSSCache nss_cache = (NSSCache)NSS_CACHE_INIT;
+        _c_cleanup_(nss_cache_deinit) NSSCache nss_cache = NSS_CACHE_INIT;
         _c_cleanup_(c_freep) uint32_t *system_console_users = NULL;
         size_t n_system_console_users;
         Service *service;
@@ -1275,6 +1275,10 @@ static int manager_reload_config(Manager *manager) {
 
         c_rbtree_for_each_entry(service, &manager->services, rb)
                 service->state = SERVICE_STATE_DEFUNCT;
+
+        r = nss_cache_populate(&nss_cache);
+        if (r)
+                return error_fold(r);
 
         r = manager_parse_config(manager, &root, &nss_cache);
         if (r)
@@ -1354,6 +1358,10 @@ static int manager_run(Manager *manager) {
         _c_cleanup_(c_freep) uint32_t *system_console_users = NULL;
         size_t n_system_console_users;
         int r, controller[2];
+
+        r = nss_cache_populate(&nss_cache);
+        if (r)
+                return error_fold(r);
 
         r = manager_parse_config(manager, &root, &nss_cache);
         if (r)

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -114,11 +114,6 @@ int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group) {
         unsigned long long int gid;
         int r;
 
-        if (!strcmp(group, "root")) {
-                *gidp = 0;
-                return 0;
-        }
-
         static_assert(sizeof(gid_t) == sizeof(uint32_t), "gid_t is not 32 bits");
         errno = 0;
         gid = strtoull(group, &end, 10);

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -87,9 +87,13 @@ int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user) {
         } else {
                 struct passwd *pw;
 
+                fprintf(stderr, "Looking up UID for user '%s' over NSS...\n", user);
+
                 pw = getpwnam(user);
                 if (!pw)
                         return NSS_CACHE_E_INVALID_NAME;
+
+                fprintf(stderr, "NSS returned UID %u for user '%s'\n", pw->pw_uid, user);
 
                 r = nss_cache_node_new(&node, user, pw->pw_uid);
                 if (r)
@@ -129,9 +133,13 @@ int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group) {
         } else {
                 struct group *gr;
 
+                fprintf(stderr, "Looking up GID for group '%s' over NSS...\n", group);
+
                 gr = getgrnam(group);
                 if (!gr)
                         return NSS_CACHE_E_INVALID_NAME;
+
+                fprintf(stderr, "NSS returned GID %u for group '%s'\n", gr->gr_gid, group);
 
                 r = nss_cache_node_new(&node, group, gr->gr_gid);
                 if (r)

--- a/src/launch/nss-cache.h
+++ b/src/launch/nss-cache.h
@@ -32,5 +32,7 @@ struct NSSCache {
 void nss_cache_init(NSSCache *cache);
 void nss_cache_deinit(NSSCache *cache);
 
+int nss_cache_populate(NSSCache *cache);
+
 int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user);
 int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group);


### PR DESCRIPTION
NSS is prone to deadlocks with dbus. Read /etc/{passwd,group} directly where possible, and only fall back to NSS if we have to.

When we fall back to NSS, log before/after each call to make deadlocks easier to debug.