### PR TITLE
match: index by path/interface/member in addition to destination

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -2004,7 +2004,7 @@ int driver_goodbye(Peer *peer, bool silent) {
         c_list_for_each_entry_safe(reply, reply_safe, &peer->owned_replies.reply_list, owner_link)
                 reply_slot_free(reply);
 
-        c_list_for_each_entry_safe(rule, rule_safe, &peer->sender_matches.rule_list, registry_link)
+        c_list_for_each_entry_safe(rule, rule_safe, &peer->sender_matches.subscription_list, registry_link)
                 match_rule_unlink(rule);
 
         c_rbtree_for_each_entry_safe_postorder_unlink(ownership, ownership_safe, &peer->owned_names.ownership_tree, owner_node) {
@@ -2036,7 +2036,7 @@ int driver_goodbye(Peer *peer, bool silent) {
                 peer_stop_monitor(peer);
         }
 
-        c_list_for_each_entry_safe(rule, rule_safe, &peer->name_owner_changed_matches.rule_list, registry_link)
+        c_list_for_each_entry_safe(rule, rule_safe, &peer->name_owner_changed_matches.subscription_list, registry_link)
                 match_rule_unlink(rule);
 
         c_rbtree_for_each_entry_safe_postorder_unlink(reply, reply_safe, &peer->replies.reply_tree, registry_node) {

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1995,7 +1995,6 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
 
 int driver_goodbye(Peer *peer, bool silent) {
         ReplySlot *reply, *reply_safe;
-        MatchRule *rule, *rule_safe;
         NameOwnership *ownership, *ownership_safe;
         int r;
 
@@ -2004,8 +2003,7 @@ int driver_goodbye(Peer *peer, bool silent) {
         c_list_for_each_entry_safe(reply, reply_safe, &peer->owned_replies.reply_list, owner_link)
                 reply_slot_free(reply);
 
-        c_list_for_each_entry_safe(rule, rule_safe, &peer->sender_matches.subscription_list, registry_link)
-                match_rule_unlink(rule);
+        match_registry_flush(&peer->sender_matches);
 
         c_rbtree_for_each_entry_safe_postorder_unlink(ownership, ownership_safe, &peer->owned_names.ownership_tree, owner_node) {
                 NameChange change;
@@ -2036,8 +2034,7 @@ int driver_goodbye(Peer *peer, bool silent) {
                 peer_stop_monitor(peer);
         }
 
-        c_list_for_each_entry_safe(rule, rule_safe, &peer->name_owner_changed_matches.subscription_list, registry_link)
-                match_rule_unlink(rule);
+        match_registry_flush(&peer->name_owner_changed_matches);
 
         c_rbtree_for_each_entry_safe_postorder_unlink(reply, reply_safe, &peer->replies.reply_tree, registry_node) {
                 Peer *sender = c_container_of(reply->owner, Peer, owned_replies);

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -468,7 +468,7 @@ int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor) {
                 if (monitor)
                         c_list_link_tail(&registry->monitor_list, &rule->registry_link);
                 else
-                        c_list_link_tail(&registry->rule_list, &rule->registry_link);
+                        c_list_link_tail(&registry->subscription_list, &rule->registry_link);
         }
 
         return 0;
@@ -488,8 +488,8 @@ bool match_rule_match_filter(MatchRule *rule, MatchFilter *filter) {
         return match_keys_match_filter(&rule->keys, filter);
 }
 
-MatchRule *match_rule_next_match(MatchRegistry *registry, MatchRule *rule, MatchFilter *filter) {
-        c_list_for_each_entry_continue(rule, &registry->rule_list, registry_link)
+MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MatchFilter *filter) {
+        c_list_for_each_entry_continue(rule, &registry->subscription_list, registry_link)
                 if (match_rule_match_filter(rule, filter))
                         return rule;
 
@@ -580,6 +580,6 @@ void match_registry_init(MatchRegistry *registry) {
  * match_registry_deinit() - XXX
  */
 void match_registry_deinit(MatchRegistry *registry) {
-        assert(c_list_is_empty(&registry->rule_list));
+        assert(c_list_is_empty(&registry->subscription_list));
         assert(c_list_is_empty(&registry->monitor_list));
 }

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -459,7 +459,7 @@ MatchRule *match_rule_user_unref(MatchRule *rule) {
 /**
  * match_rule_link() - XXX
  */
-void match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor) {
+int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor) {
         if (rule->registry) {
                 assert(registry == rule->registry);
                 assert(c_list_is_linked(&rule->registry_link));
@@ -470,6 +470,8 @@ void match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor) {
                 else
                         c_list_link_tail(&registry->rule_list, &rule->registry_link);
         }
+
+        return 0;
 }
 
 /**

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -583,3 +583,13 @@ void match_registry_deinit(MatchRegistry *registry) {
         assert(c_list_is_empty(&registry->subscription_list));
         assert(c_list_is_empty(&registry->monitor_list));
 }
+
+/**
+ * mach_registry_flush() - XXX
+ */
+void match_registry_flush(MatchRegistry *registry) {
+        MatchRule *rule, *rule_safe;
+
+        c_list_for_each_entry_safe(rule, rule_safe, &registry->subscription_list, registry_link)
+                match_rule_unlink(rule);
+}

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -85,13 +85,13 @@ struct MatchOwner {
         }
 
 struct MatchRegistry {
-        CList rule_list;
+        CList subscription_list;
         CList monitor_list;
 };
 
-#define MATCH_REGISTRY_INIT(_x) {                                               \
-                .rule_list = (CList)C_LIST_INIT((_x).rule_list),                \
-                .monitor_list = (CList)C_LIST_INIT((_x).monitor_list),          \
+#define MATCH_REGISTRY_INIT(_x) {                                                       \
+                .subscription_list = (CList)C_LIST_INIT((_x).subscription_list),        \
+                .monitor_list = (CList)C_LIST_INIT((_x).monitor_list),                  \
         }
 
 /* rules */
@@ -104,7 +104,7 @@ void match_rule_unlink(MatchRule *rule);
 
 bool match_rule_match_filter(MatchRule *rule, MatchFilter *filter);
 
-MatchRule *match_rule_next_match(MatchRegistry *registry, MatchRule *rule, MatchFilter *filter);
+MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MatchFilter *filter);
 MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rule, MatchFilter *filter);
 
 C_DEFINE_CLEANUP(MatchRule *, match_rule_user_unref);

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -13,6 +13,7 @@
 typedef struct MatchFilter MatchFilter;
 typedef struct MatchKeys MatchKeys;
 typedef struct MatchOwner MatchOwner;
+typedef struct MatchRegistryByPath MatchRegistryByPath;
 typedef struct MatchRegistry MatchRegistry;
 typedef struct MatchRule MatchRule;
 
@@ -59,9 +60,10 @@ struct MatchKeys {
 
 struct MatchRule {
         unsigned long int n_user_refs;
+        MatchRegistryByPath *registry_by_path;
+        CList registry_link;
         MatchRegistry *registry;
         MatchOwner *owner;
-        CList registry_link;
         CRBNode owner_node;
 
         UserCharge charge[2];
@@ -84,14 +86,27 @@ struct MatchOwner {
                 .rule_tree = C_RBTREE_INIT,     \
         }
 
-struct MatchRegistry {
-        CList subscription_list;
-        CList monitor_list;
+struct MatchRegistryByPath {
+        unsigned long n_refs;
+        CList rule_list;
+        CRBNode registry_node;
+        char path[];
 };
 
-#define MATCH_REGISTRY_INIT(_x) {                                                       \
-                .subscription_list = (CList)C_LIST_INIT((_x).subscription_list),        \
-                .monitor_list = (CList)C_LIST_INIT((_x).monitor_list),                  \
+#define MATCH_REGISTRY_BY_PATH_INIT(_x) {                               \
+                .n_refs = 1,                                            \
+                .rule_list = C_LIST_INIT((_x).rule_list),               \
+                .registry_node = C_RBNODE_INIT((_x).registry_node),     \
+        }
+
+struct MatchRegistry {
+        CRBTree subscription_tree;
+        CRBTree monitor_tree;
+};
+
+#define MATCH_REGISTRY_INIT(_x) {                       \
+                .subscription_tree = C_RBTREE_INIT,     \
+                .monitor_tree = C_RBTREE_INIT,          \
         }
 
 /* rules */

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -122,3 +122,5 @@ int match_owner_find_rule(MatchOwner *owner, MatchRule **rulep, const char *rule
 
 void match_registry_init(MatchRegistry *registry);
 void match_registry_deinit(MatchRegistry *registry);
+
+void match_registry_flush(MatchRegistry *registry);

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -13,6 +13,7 @@
 typedef struct MatchFilter MatchFilter;
 typedef struct MatchKeys MatchKeys;
 typedef struct MatchOwner MatchOwner;
+typedef struct MatchRegistryByInterface MatchRegistryByInterface;
 typedef struct MatchRegistryByPath MatchRegistryByPath;
 typedef struct MatchRegistry MatchRegistry;
 typedef struct MatchRule MatchRule;
@@ -60,7 +61,7 @@ struct MatchKeys {
 
 struct MatchRule {
         unsigned long int n_user_refs;
-        MatchRegistryByPath *registry_by_path;
+        MatchRegistryByInterface *registry_by_interface;
         CList registry_link;
         MatchRegistry *registry;
         MatchOwner *owner;
@@ -86,16 +87,30 @@ struct MatchOwner {
                 .rule_tree = C_RBTREE_INIT,     \
         }
 
-struct MatchRegistryByPath {
+struct MatchRegistryByInterface {
         unsigned long n_refs;
         CList rule_list;
+        MatchRegistryByPath *registry_by_path;
+        CRBNode registry_node;
+        char interface[];
+};
+
+#define MATCH_REGISTRY_BY_INTERFACE_INIT(_x) {                          \
+                .n_refs = 1,                                            \
+                .rule_list = C_LIST_INIT((_x).rule_list),               \
+                .registry_node = C_RBNODE_INIT((_x).registry_node),     \
+        }
+
+struct MatchRegistryByPath {
+        unsigned long n_refs;
+        CRBTree interface_tree;
         CRBNode registry_node;
         char path[];
 };
 
 #define MATCH_REGISTRY_BY_PATH_INIT(_x) {                               \
                 .n_refs = 1,                                            \
-                .rule_list = C_LIST_INIT((_x).rule_list),               \
+                .interface_tree = C_RBTREE_INIT,                        \
                 .registry_node = C_RBNODE_INIT((_x).registry_node),     \
         }
 

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -99,7 +99,7 @@ struct MatchRegistry {
 MatchRule *match_rule_user_ref(MatchRule *rule);
 MatchRule *match_rule_user_unref(MatchRule *rule);
 
-void match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor);
+int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor);
 void match_rule_unlink(MatchRule *rule);
 
 bool match_rule_match_filter(MatchRule *rule, MatchFilter *filter);

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -13,6 +13,7 @@
 typedef struct MatchFilter MatchFilter;
 typedef struct MatchKeys MatchKeys;
 typedef struct MatchOwner MatchOwner;
+typedef struct MatchRegistryByMember MatchRegistryByMember;
 typedef struct MatchRegistryByInterface MatchRegistryByInterface;
 typedef struct MatchRegistryByPath MatchRegistryByPath;
 typedef struct MatchRegistry MatchRegistry;
@@ -61,7 +62,7 @@ struct MatchKeys {
 
 struct MatchRule {
         unsigned long int n_user_refs;
-        MatchRegistryByInterface *registry_by_interface;
+        MatchRegistryByMember *registry_by_member;
         CList registry_link;
         MatchRegistry *registry;
         MatchOwner *owner;
@@ -87,9 +88,23 @@ struct MatchOwner {
                 .rule_tree = C_RBTREE_INIT,     \
         }
 
-struct MatchRegistryByInterface {
+struct MatchRegistryByMember {
         unsigned long n_refs;
         CList rule_list;
+        MatchRegistryByInterface *registry_by_interface;
+        CRBNode registry_node;
+        char member[];
+};
+
+#define MATCH_REGISTRY_BY_MEMBER_INIT(_x) {                             \
+                .n_refs = 1,                                            \
+                .rule_list = C_LIST_INIT((_x).rule_list),               \
+                .registry_node = C_RBNODE_INIT((_x).registry_node),     \
+        }
+
+struct MatchRegistryByInterface {
+        unsigned long n_refs;
+        CRBTree member_tree;
         MatchRegistryByPath *registry_by_path;
         CRBNode registry_node;
         char interface[];
@@ -97,7 +112,7 @@ struct MatchRegistryByInterface {
 
 #define MATCH_REGISTRY_BY_INTERFACE_INIT(_x) {                          \
                 .n_refs = 1,                                            \
-                .rule_list = C_LIST_INIT((_x).rule_list),               \
+                .member_tree = C_RBTREE_INIT,                           \
                 .registry_node = C_RBNODE_INIT((_x).registry_node),     \
         }
 

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -613,7 +613,7 @@ static int peer_broadcast_to_matches(PolicySnapshot *sender_policy, NameSet *sen
         MatchRule *rule;
         int r;
 
-        for (rule = match_rule_next_match(matches, NULL, filter); rule; rule = match_rule_next_match(matches, rule, filter)) {
+        for (rule = match_rule_next_subscription_match(matches, NULL, filter); rule; rule = match_rule_next_subscription_match(matches, rule, filter)) {
                 Peer *receiver = c_container_of(rule->owner, Peer, owned_matches);
                 NameSet receiver_names = NAME_SET_INIT_FROM_OWNER(&receiver->owned_names);
 

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -365,7 +365,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
         int r;
 
         if (!rule->keys.sender) {
-                match_rule_link(rule, &peer->bus->wildcard_matches, monitor);
+                r = match_rule_link(rule, &peer->bus->wildcard_matches, monitor);
+                if (r)
+                        return error_fold(r);
         } else if (strcmp(rule->keys.sender, "org.freedesktop.DBus") == 0) {
                 if (rule->keys.filter.member &&
                     strcmp(rule->keys.filter.member, "NameOwnerChanged") == 0 &&
@@ -380,7 +382,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                         case ADDRESS_TYPE_ID: {
                                 owner = peer_registry_find_peer(&peer->bus->peers, addr.id);
                                 if (owner) {
-                                        match_rule_link(rule, &owner->name_owner_changed_matches, monitor);
+                                        r = match_rule_link(rule, &owner->name_owner_changed_matches, monitor);
+                                        if (r)
+                                                return error_fold(r);
                                 } else if (addr.id >= peer->bus->peers.ids) {
                                         /*
                                          * This peer does not yet exist, but it could
@@ -392,7 +396,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                                          * forthcoming peer, so this is most likely
                                          * a bug in a client.
                                          */
-                                        match_rule_link(rule, &peer->bus->sender_matches, monitor);
+                                        r = match_rule_link(rule, &peer->bus->sender_matches, monitor);
+                                        if (r)
+                                                return error_fold(r);
                                 } else {
                                         /*
                                          * The peer has already disconnected and will
@@ -414,7 +420,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                                 if (r)
                                         return error_fold(r);
 
-                                match_rule_link(rule, &name->name_owner_changed_matches, monitor);
+                                r = match_rule_link(rule, &name->name_owner_changed_matches, monitor);
+                                if (r)
+                                        return error_fold(r);
                                 name_ref(name); /* this reference must be explicitly released */
                                 break;
                         }
@@ -427,7 +435,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                          * install other (unexpected) matches here, they will always be false negatives
                          * but for the sake of simplicity we do not attempt to optimize them away.
                          */
-                        match_rule_link(rule, &peer->bus->sender_matches, monitor);
+                        r = match_rule_link(rule, &peer->bus->sender_matches, monitor);
+                        if (r)
+                                return error_fold(r);
                 }
         } else {
                 address_from_string(&addr, rule->keys.sender);
@@ -443,7 +453,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                                  * match.
                                  */
                                 rule->keys.filter.sender = addr.id;
-                                match_rule_link(rule, &peer->bus->wildcard_matches, monitor);
+                                r = match_rule_link(rule, &peer->bus->wildcard_matches, monitor);
+                                if (r)
+                                        return error_fold(r);
                         } else {
                                 /*
                                  * The peer has already disconnected and will
@@ -461,7 +473,9 @@ static int peer_link_match(Peer *peer, MatchRule *rule, bool monitor) {
                         if (r)
                                 return error_fold(r);
 
-                        match_rule_link(rule, &name->sender_matches, monitor);
+                        r = match_rule_link(rule, &name->sender_matches, monitor);
+                        if (r)
+                                return error_fold(r);
                         name_ref(name); /* this reference must be explicitly released */
                         break;
                 }

--- a/src/bus/test-match.c
+++ b/src/bus/test-match.c
@@ -126,7 +126,8 @@ static bool test_match(const char *match_string, MatchFilter *filter) {
         r = match_owner_ref_rule(&owner, &rule, NULL, match_string);
         assert(!r);
 
-        match_rule_link(rule, &registry, false);
+        r = match_rule_link(rule, &registry, false);
+        assert(!r);
 
         rule1 = match_rule_next_match(&registry, NULL, filter);
         assert(!rule1 || rule1 == rule);
@@ -261,22 +262,26 @@ static void test_iterator(void) {
         r = match_owner_ref_rule(&owner1, &rule1, NULL, "");
         assert(!r);
 
-        match_rule_link(rule1, &registry, false);
+        r = match_rule_link(rule1, &registry, false);
+        assert(!r);
 
         r = match_owner_ref_rule(&owner1, &rule2, NULL, "");
         assert(!r);
 
-        match_rule_link(rule2, &registry, false);
+        r = match_rule_link(rule2, &registry, false);
+        assert(!r);
 
         r = match_owner_ref_rule(&owner2, &rule3, NULL, "");
         assert(!r);
 
-        match_rule_link(rule3, &registry, false);
+        r = match_rule_link(rule3, &registry, false);
+        assert(!r);
 
         r = match_owner_ref_rule(&owner2, &rule4, NULL, "");
         assert(!r);
 
-        match_rule_link(rule4, &registry, false);
+        r = match_rule_link(rule4, &registry, false);
+        assert(!r);
 
         rule = match_rule_next_match(&registry, NULL, &filter);
         assert(rule == rule1);

--- a/src/bus/test-match.c
+++ b/src/bus/test-match.c
@@ -129,7 +129,7 @@ static bool test_match(const char *match_string, MatchFilter *filter) {
         r = match_rule_link(rule, &registry, false);
         assert(!r);
 
-        rule1 = match_rule_next_match(&registry, NULL, filter);
+        rule1 = match_rule_next_subscription_match(&registry, NULL, filter);
         assert(!rule1 || rule1 == rule);
 
         match_rule_user_unref(rule);
@@ -283,13 +283,13 @@ static void test_iterator(void) {
         r = match_rule_link(rule4, &registry, false);
         assert(!r);
 
-        rule = match_rule_next_match(&registry, NULL, &filter);
+        rule = match_rule_next_subscription_match(&registry, NULL, &filter);
         assert(rule == rule1);
 
-        rule = match_rule_next_match(&registry, rule, &filter);
+        rule = match_rule_next_subscription_match(&registry, rule, &filter);
         assert(rule == rule3);
 
-        rule = match_rule_next_match(&registry, rule, &filter);
+        rule = match_rule_next_subscription_match(&registry, rule, &filter);
         assert(!rule);
 
         match_rule_user_unref(rule4);


### PR DESCRIPTION
This should all but eliminate false-positives when iterating potential matches for a signal.

In a follow-up, we will ref-count identical matches, to further reduce the number of matches we have to linearly iterate through.