### PR TITLE
driver: add Peer interface

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -38,7 +38,7 @@ static int broker_dispatch_signals(DispatchFile *file) {
         return DISPATCH_E_EXIT;
 }
 
-int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects) {
+int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects) {
         _c_cleanup_(broker_freep) Broker *broker = NULL;
         struct ucred ucred;
         socklen_t z;
@@ -80,7 +80,7 @@ int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_byt
         /* XXX: make this run-time optional */
         log_set_lossy(&broker->log, true);
 
-        r = bus_init(&broker->bus, &broker->log, max_bytes, max_fds, max_matches, max_objects);
+        r = bus_init(&broker->bus, &broker->log, machine_id, max_bytes, max_fds, max_matches, max_objects);
         if (r)
                 return error_fold(r);
 

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -33,7 +33,7 @@ struct Broker {
 
 /* broker */
 
-int broker_new(Broker **brokerp, int log_fd, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects);
+int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects);
 Broker *broker_free(Broker *broker);
 
 int broker_run(Broker *broker);

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -17,6 +17,7 @@
 
 int bus_init(Bus *bus,
              Log *log,
+             const char *machine_id,
              unsigned int max_bytes,
              unsigned int max_fds,
              unsigned int max_matches,
@@ -25,8 +26,13 @@ int bus_init(Bus *bus,
         void *random;
         int r;
 
+        if (strlen(machine_id) + 1 != sizeof(bus->machine_id))
+                return error_origin(-EINVAL);
+
         *bus = (Bus)BUS_NULL(*bus);
         bus->log = log;
+
+        memcpy(bus->machine_id, machine_id, sizeof(bus->machine_id));
 
         random = (void *)getauxval(AT_RANDOM);
         assert(random);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -36,6 +36,7 @@ struct Bus {
         pid_t pid;
         char *seclabel;
         size_t n_seclabel;
+        char machine_id[33];
         char guid[16];
 
         UserRegistry users;
@@ -62,6 +63,7 @@ struct Bus {
 
 int bus_init(Bus *bus,
              Log *log,
+             const char *machine_id,
              unsigned int max_bytes,
              unsigned int max_fds,
              unsigned int max_matches,

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1920,7 +1920,13 @@ static int driver_dispatch_internal(Peer *peer, Message *message) {
         if (r)
                 return error_trace(r);
 
-        if (_c_unlikely_(c_string_equal(message->metadata.fields.destination, "org.freedesktop.DBus"))) {
+        if (_c_unlikely_(c_string_equal(message->metadata.fields.destination, "org.freedesktop.DBus") ||
+                         (message->metadata.header.type == DBUS_MESSAGE_TYPE_METHOD_CALL &&
+                          !message->metadata.fields.destination))) {
+                /*
+                 * Method calls without a destination are implicitly treated as if they were destined for
+                 * the driver.
+                 */
                 return error_trace(driver_dispatch_interface(peer,
                                                              message_read_serial(message),
                                                              message->metadata.fields.interface,

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -1885,6 +1885,31 @@ static void test_get_machine_id(void) {
         util_broker_terminate(broker);
 }
 
+static void test_no_destination(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        util_broker_spawn(broker);
+
+        /* don't provide a destination, verify that the driver answers regardless */
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+                _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message = NULL;
+
+                util_broker_connect(broker, &bus);
+
+                r = sd_bus_message_new_method_call(bus, &message, NULL, "/org/freedestkop/DBus",
+                                                   "org.freedesktop.DBus.Peer", "Ping");
+                assert(r >= 0);
+
+                r = sd_bus_call(bus, message, 0, NULL, NULL);
+                assert(r >= 0);
+        }
+
+        util_broker_terminate(broker);
+}
+
 int main(int argc, char **argv) {
         test_hello();
         test_request_name();
@@ -1909,6 +1934,7 @@ int main(int argc, char **argv) {
         test_become_monitor();
         test_ping();
         test_get_machine_id();
+        test_no_destination();
 
         return 0;
 }

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -191,6 +191,7 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
                 r = execl("./src/dbus-broker",
                           "./src/dbus-broker",
                           "--controller", fdstr,
+                          "--machine-id", "0123456789abcdef0123456789abcdef",
                           (char *)NULL);
                 /* execl(2) only returns on error */
                 assert(r >= 0);


### PR DESCRIPTION
This is required by the spec. Also, allow method calls with an empty destination.