### PR TITLE
launcher/start-service: use job-mode 'replace'

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -455,7 +455,7 @@ static int manager_start_unit(Manager *manager, Service *service) {
         if (r < 0)
                 return error_origin(r);
 
-        r = sd_bus_message_append(method_call, "ss", service->unit, "fail");
+        r = sd_bus_message_append(method_call, "ss", service->unit, "replace");
         if (r < 0)
                 return error_origin(r);
 


### PR DESCRIPTION
We used to use mode 'fail', but that implied we would fail in case there was a
racing stop job. In that case we want to override the stop with a start.

Signed-off-by: Tom Gundersen <teg@jklm.no>