### PR TITLE
Extend NSS Cache

### DIFF
--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -106,6 +106,12 @@ struct ConfigNode {
 
         union {
                 struct {
+                        uint32_t uid;
+                        uint32_t gid;
+                        bool valid : 1;
+                } user;
+
+                struct {
                         ConfigPath *dir;
                 } includedir;
 

--- a/src/launch/nss-cache.c
+++ b/src/launch/nss-cache.c
@@ -293,7 +293,7 @@ int nss_cache_populate(NSSCache *cache) {
         return 0;
 }
 
-int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, const char *name) {
+int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, uint32_t *gidp, const char *name) {
         unsigned long long id;
         NSSCacheNode *node;
         struct passwd *pw;
@@ -349,7 +349,10 @@ int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, const char *name) {
                         return r;
         }
 
-        *uidp = pw->pw_uid;
+        if (uidp)
+                *uidp = pw->pw_uid;
+        if (gidp)
+                *gidp = pw->pw_gid;
         return 0;
 }
 

--- a/src/launch/nss-cache.h
+++ b/src/launch/nss-cache.h
@@ -37,5 +37,5 @@ void nss_cache_deinit(NSSCache *cache);
 
 int nss_cache_populate(NSSCache *cache);
 
-int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, const char *user);
+int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, uint32_t *gidp, const char *user);
 int nss_cache_get_gid(NSSCache *cache, uint32_t *gidp, const char *group);

--- a/src/launch/nss-cache.h
+++ b/src/launch/nss-cache.h
@@ -7,7 +7,6 @@
 #include <c-macro.h>
 #include <c-rbtree.h>
 #include <stdlib.h>
-#include <sys/types.h>
 
 typedef struct NSSCache NSSCache;
 
@@ -19,12 +18,16 @@ enum {
 
 struct NSSCache {
         CRBTree user_tree;
+        CRBTree uid_tree;
         CRBTree group_tree;
+        CRBTree gid_tree;
 };
 
 #define NSS_CACHE_INIT {                                                        \
                 .user_tree = C_RBTREE_INIT,                                     \
+                .uid_tree = C_RBTREE_INIT,                                      \
                 .group_tree = C_RBTREE_INIT,                                    \
+                .gid_tree = C_RBTREE_INIT,                                      \
         }
 
 /* nss cache */
@@ -34,5 +37,5 @@ void nss_cache_deinit(NSSCache *cache);
 
 int nss_cache_populate(NSSCache *cache);
 
-int nss_cache_get_uid(NSSCache *cache, uid_t *uidp, const char *user);
-int nss_cache_get_gid(NSSCache *cache, gid_t *gidp, const char *group);
+int nss_cache_get_uid(NSSCache *cache, uint32_t *uidp, const char *user);
+int nss_cache_get_gid(NSSCache *cache, uint32_t *gidp, const char *group);

--- a/src/launch/test-nss-cache.c
+++ b/src/launch/test-nss-cache.c
@@ -1,0 +1,34 @@
+/*
+ * Test NSS Cache
+ */
+
+#include <c-list.h>
+#include <c-macro.h>
+#include <stdlib.h>
+#include "launch/nss-cache.h"
+
+static void test_nss_cache(void) {
+        _c_cleanup_(nss_cache_deinit) NSSCache cache = NSS_CACHE_INIT;
+        uint32_t uid, gid;
+        int r;
+
+        r = nss_cache_get_uid(&cache, NULL, NULL, "com.example.InvalidUser");
+        assert(r == NSS_CACHE_E_INVALID_NAME);
+
+        r = nss_cache_get_gid(&cache, NULL, "com.example.InvalidGroup");
+        assert(r == NSS_CACHE_E_INVALID_NAME);
+
+        r = nss_cache_get_uid(&cache, &uid, &gid, "root");
+        assert(!r);
+        assert(uid == 0);
+        assert(gid == 0);
+
+        r = nss_cache_get_gid(&cache, &gid, "root");
+        assert(!r);
+        assert(gid == 0);
+}
+
+int main(int argc, char **argv) {
+        test_nss_cache();
+        return 0;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -171,6 +171,9 @@ test('D-Bus Message Abstraction', test_message)
 test_name = executable('test-name', ['bus/test-name.c'], dependencies: dep_bus)
 test('Name Registry', test_name)
 
+test_nss_cache = executable('test-nss-cache', ['launch/test-nss-cache.c'], dependencies: dep_bus)
+test('NSS Cache', test_nss_cache)
+
 test_peersec = executable('test-peersec', ['util/test-peersec.c'], dependencies: dep_bus)
 test('SO_PEERSEC Queries', test_peersec)
 


### PR DESCRIPTION
Hey

This is in preparation for the `<user>%</user>` attribute of the XML config. This does not fully implement it, but only contains the preparations in the NSS cache.

The only undiscussed change here is the re-introduction of the 'root' group as pre-populated entry. Given that we have to pre-propulate the full "struct passwd" now, this means that we must also know the "pw->pw_gid" entry. Lets just define this as 0 and reintroduce the 'root' group as group 0. This is universally true and should be fine.

Thanks
David