### PR TITLE
broker: org.bus1.DBus.Launcher -> org.bus1.DBus.Controller

### DIFF
--- a/docs/dbus-broker.rst
+++ b/docs/dbus-broker.rst
@@ -216,8 +216,8 @@ it is up to the controller to make sure not to perform **blocking** recursive
 calls back into the broker (via any means).
 
 |
-| **node** /org/bus1/DBus/Launcher {
-|     **interface** org.bus1.DBus.Launcher {
+| **node** /org/bus1/DBus/Controller {
+|     **interface** org.bus1.DBus.Controller {
 |
 |         # This function is called for each client-request of
 |         # *org.freedesktop.DBus.ReloadConfig()*.

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -719,8 +719,8 @@ int controller_dbus_send_reload(Controller *controller, User *user, uint32_t ser
         c_dvar_begin_write(&var, type, 1);
         c_dvar_write(&var, "((yyyyuu[(y<o>)(y<s>)(y<s>)])())",
                      c_dvar_is_big_endian(&var) ? 'B' : 'l', DBUS_MESSAGE_TYPE_METHOD_CALL, 0, 1, 0, serial,
-                     DBUS_MESSAGE_FIELD_PATH, c_dvar_type_o, "/org/bus1/DBus/Launcher",
-                     DBUS_MESSAGE_FIELD_INTERFACE, c_dvar_type_s, "org.bus1.DBus.Launcher",
+                     DBUS_MESSAGE_FIELD_PATH, c_dvar_type_o, "/org/bus1/DBus/Controller",
+                     DBUS_MESSAGE_FIELD_INTERFACE, c_dvar_type_s, "org.bus1.DBus.Controller",
                      DBUS_MESSAGE_FIELD_MEMBER, c_dvar_type_s, "ReloadConfig");
 
         r = c_dvar_end_write(&var, &data, &n_data);

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -1415,7 +1415,7 @@ static int manager_run(Manager *manager) {
                 return error_trace(r);
         }
 
-        r = sd_bus_add_object_vtable(manager->bus_controller, NULL, "/org/bus1/DBus/Launcher", "org.bus1.DBus.Launcher", manager_vtable, manager);
+        r = sd_bus_add_object_vtable(manager->bus_controller, NULL, "/org/bus1/DBus/Controller", "org.bus1.DBus.Controller", manager_vtable, manager);
         if (r < 0)
                 return error_origin(r);
 

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -215,7 +215,7 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
         r = sd_bus_attach_event(bus, event, SD_EVENT_PRIORITY_NORMAL);
         assert(r >= 0);
 
-        r = sd_bus_add_object_vtable(bus, NULL, "/org/bus1/DBus/Launcher", "org.bus1.DBus.Launcher", util_vtable, NULL);
+        r = sd_bus_add_object_vtable(bus, NULL, "/org/bus1/DBus/Controller", "org.bus1.DBus.Controller", util_vtable, NULL);
         assert(r >= 0);
 
         r = sd_bus_start(bus);


### PR DESCRIPTION
We never use the term "Launcher" to describe technical parts of dbus-broker. We always call it "Controller". Make sure the D-Bus interface uses the same terms.