### PR TITLE
launch: drop privileges before startup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ dep_thread = dependency('threads')
 use_audit = get_option('audit')
 if use_audit
         dep_libaudit = dependency('audit', version: '>=2.7')
+        dep_libcapng = dependency('libcap-ng', version: '>=0.6')
 endif
 
 #

--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -24,6 +24,7 @@
 #include "launch/config.h"
 #include "launch/nss-cache.h"
 #include "launch/policy.h"
+#include "util/audit.h"
 #include "util/error.h"
 #include "util/log.h"
 
@@ -335,6 +336,12 @@ static noreturn void manager_run_child(Manager *manager, int fd_log, int fd_cont
                 NULL,
         };
         int r;
+
+        if (manager->uid != (uint32_t)-1) {
+                r = util_audit_drop_permissions(manager->uid, manager->gid);
+                if (r)
+                        goto exit;
+        }
 
         r = prctl(PR_SET_PDEATHSIG, SIGTERM);
         if (r) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,7 @@ if use_audit
         ]
         deps_bus += [
                 dep_libaudit,
+                dep_libcapng,
         ]
 else
         sources_bus += [

--- a/src/util/audit-fallback.c
+++ b/src/util/audit-fallback.c
@@ -9,9 +9,29 @@
  */
 
 #include <c-macro.h>
+#include <grp.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "util/audit.h"
 #include "util/error.h"
+
+/* see src/util/audit.c for details */
+int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
+        int r;
+
+        /* for compatibility to dbus-daemon, this must be non-fatal */
+        setgroups(0, NULL);
+
+        r = setgid(gid);
+        if (r < 0)
+                return error_origin(-errno);
+
+        r = setuid(uid);
+        if (r < 0)
+                return error_origin(-errno);
+
+        return 0;
+}
 
 int util_audit_log(const char *message, uid_t uid) {
         int r;

--- a/src/util/audit.h
+++ b/src/util/audit.h
@@ -7,6 +7,7 @@
 #include <c-macro.h>
 #include <stdlib.h>
 
+int util_audit_drop_permissions(uint32_t uid, uint32_t gid);
 int util_audit_log(const char *message, uid_t uid);
 
 int util_audit_init_global(void);


### PR DESCRIPTION
Make sure to drop privileges before executing dbus-broker. Look at the
<user> XML attribute and apply the uid/gid if set.