### PR TITLE
build: enable selinux+audit in CI

### DIFF
--- a/.cherryci/ci-test
+++ b/.cherryci/ci-test
@@ -6,7 +6,7 @@ rm -Rf "./ci-build"
 mkdir "./ci-build"
 cd "./ci-build"
 
-${CHERRY_LIB_MESONSETUP} . "${CHERRY_LIB_SRCDIR}"
+${CHERRY_LIB_MESONSETUP} -Daudit=true -Dselinux=true . "${CHERRY_LIB_SRCDIR}"
 ${CHERRY_LIB_NINJABUILD}
 ${CHERRY_LIB_MESONTEST}
 # XXX: Valgrind and sd-bus / dbus-daemon does not work nicely. We should


### PR DESCRIPTION
Now that the CI environment contains the required dependencies, lets
try and enable selinux+audit.