### PR TITLE
launcher: notify systemd about reloading

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -1312,6 +1312,10 @@ static int manager_reload_config(Manager *manager) {
         Service *service;
         int r;
 
+        r = sd_notify(false, "RELOADING=1");
+        if (r < 0)
+                return error_origin(r);
+
         c_rbtree_for_each_entry(service, &manager->services, rb)
                 service->state = SERVICE_STATE_DEFUNCT;
 
@@ -1349,6 +1353,10 @@ static int manager_reload_config(Manager *manager) {
         r = manager_add_services(manager);
         if (r)
                 return error_trace(r);
+
+        r = sd_notify(false, "READY=1");
+        if (r < 0)
+                return error_origin(r);
 
         return 0;
 }


### PR DESCRIPTION
Hook into the reload notification as systemd expects. This appears to be purely
informational, but seems worth following the recommendations nonetheless.

Signed-off-by: Tom Gundersen <teg@jklm.no>