### PR TITLE
launcher/start-service: use job-mode 'replace' also for transient units

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -504,7 +504,7 @@ static int manager_start_transient_unit(Manager *manager, Service *service) {
         if (r < 0)
                 return error_origin(r);
 
-        r = sd_bus_message_append(method_call, "ss", unit, "fail");
+        r = sd_bus_message_append(method_call, "ss", unit, "replace");
         if (r < 0)
                 return error_origin(r);
 


### PR DESCRIPTION
This is a follow-up to 5d90e2d571b40ad6a8e9894f3bb38fe22d50fd06.

Signed-off-by: Tom Gundersen <teg@jklm.no>