### PR TITLE
bus/log: make human-readable log-messages a bit more verbose

### DIFF
--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -222,11 +222,10 @@ int bus_get_broadcast_destinations(Bus *bus, CList *destinations, MatchRegistry 
 }
 
 
-static int bus_log_commit_policy(Bus *bus, const char *action, const char *policy_type, uint64_t sender_id, uint64_t receiver_id,
-                                 NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label,
-                                 Message *message) {
+static void bus_log_append_policy(Bus *bus, const char *action, const char *policy_type, uint64_t sender_id, uint64_t receiver_id,
+                                  NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label,
+                                  Message *message) {
         Log *log = bus->log;
-        int r;
 
         message_log_append(message, log);
 
@@ -298,15 +297,9 @@ static int bus_log_commit_policy(Bus *bus, const char *action, const char *polic
                                             i, receiver_names->snapshot->names[i]->name);
                 }
         }
-
-        r = log_commitf(log, ":1.%llu failed to %s message, due to policy.", sender_id, action);
-        if (r)
-                return error_fold(r);
-
-        return 0;
 }
 
-int bus_log_commit_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message) {
+void bus_log_append_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message) {
         const char *policy_type_str;
 
         switch (policy_type) {
@@ -320,9 +313,9 @@ int bus_log_commit_policy_send(Bus *bus, int policy_type, uint64_t sender_id, ui
                 assert(0);
         }
 
-        return bus_log_commit_policy(bus, "send", policy_type_str, sender_id, receiver_id, sender_names, receiver_names, sender_label, receiver_label, message);
+        bus_log_append_policy(bus, "send", policy_type_str, sender_id, receiver_id, sender_names, receiver_names, sender_label, receiver_label, message);
 }
 
-int bus_log_commit_policy_receive(Bus *bus, uint64_t receiver_id, uint64_t sender_id, NameSet *sender_names, NameSet *receiver_names, Message *message) {
-        return bus_log_commit_policy(bus, "receive", "internal", sender_id, receiver_id, sender_names, receiver_names, NULL, NULL, message);
+void bus_log_append_policy_receive(Bus *bus, uint64_t receiver_id, uint64_t sender_id, NameSet *sender_names, NameSet *receiver_names, Message *message) {
+        bus_log_append_policy(bus, "receive", "internal", sender_id, receiver_id, sender_names, receiver_names, NULL, NULL, message);
 }

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -73,5 +73,5 @@ Peer *bus_find_peer_by_name(Bus *bus, Name **namep, const char *name);
 int bus_get_monitor_destinations(Bus *bus, CList *destinations, Peer *sender, MessageMetadata *metadata);
 int bus_get_broadcast_destinations(Bus *bus, CList *destinations, MatchRegistry *matches, Peer *sender, MessageMetadata *metadata);
 
-int bus_log_commit_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message);
-int bus_log_commit_policy_receive(Bus *bus, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receievr_names, Message *message);
+void bus_log_append_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message);
+void bus_log_append_policy_receive(Bus *bus, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receievr_names, Message *message);

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1940,9 +1940,11 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
                         NameSet names = NAME_SET_INIT_FROM_OWNER(&peer->owned_names);
 
                         log_append_here(peer->bus->log, LOG_WARNING, 0);
-                        r = bus_log_commit_policy_send(peer->bus,
-                                                       (r == POLICY_E_ACCESS_DENIED ? BUS_LOG_POLICY_TYPE_INTERNAL : BUS_LOG_POLICY_TYPE_SELINUX),
-                                                       peer->id, ADDRESS_ID_INVALID, &names, NULL, peer->policy->seclabel, NULL, message);
+                        bus_log_append_policy_send(peer->bus,
+                                                   (r == POLICY_E_ACCESS_DENIED ? BUS_LOG_POLICY_TYPE_INTERNAL : BUS_LOG_POLICY_TYPE_SELINUX),
+                                                   peer->id, ADDRESS_ID_INVALID, &names, NULL, peer->policy->seclabel, NULL, message);
+                        r = log_commitf(peer->bus->log, "A security policy denied :1.%llu to send method call %s:%s.%s to org.freedesktop.DBus.",
+                                        peer->id, path, interface, member);
                         if (r)
                                 return error_fold(r);
 


### PR DESCRIPTION
Include more information in each log-message, so they stand on their own
even without the metadata we append.

After this pathch:

```
$ busctl monitor
Access denied.
$ busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Reboot
Access denied.
$ journalctl -b -u dbus-broker
dbus-broker[778]: A security policy denied :1.85 to send method call /org/freedesktop/DBus:org.freedesktop.DBus.Monitoring.BecomeMonitor to org.freedesktop.DBus.
dbus-broker[778]: A security policy denied :1.104 to send method call /org/freedesktop/systemd1:org.freedesktop.systemd1.Manager.Reboot to org.freedesktop.systemd1.
```

Signed-off-by: Tom Gundersen <teg@jklm.no>