### PR TITLE
log: add log messages on quota failures and related disconnects

### DIFF
--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -41,7 +41,7 @@ int bus_init(Bus *bus,
         static_assert(_USER_SLOT_N == C_ARRAY_SIZE(maxima),
                       "User accounting slot mismatch");
 
-        r = user_registry_init(&bus->users, _USER_SLOT_N, maxima);
+        r = user_registry_init(&bus->users, log, _USER_SLOT_N, maxima);
         if (r)
                 return error_fold(r);
 

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -73,5 +73,6 @@ Peer *bus_find_peer_by_name(Bus *bus, Name **namep, const char *name);
 int bus_get_monitor_destinations(Bus *bus, CList *destinations, Peer *sender, MessageMetadata *metadata);
 int bus_get_broadcast_destinations(Bus *bus, CList *destinations, MatchRegistry *matches, Peer *sender, MessageMetadata *metadata);
 
+void bus_log_append_transaction(Bus *bus, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message);
 void bus_log_append_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message);
 void bus_log_append_policy_receive(Bus *bus, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receievr_names, Message *message);

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1976,7 +1976,7 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
                         log_append_here(peer->bus->log, LOG_WARNING, 0);
                         bus_log_append_policy_send(peer->bus,
                                                    (r == POLICY_E_ACCESS_DENIED ? BUS_LOG_POLICY_TYPE_INTERNAL : BUS_LOG_POLICY_TYPE_SELINUX),
-                                                   peer->id, ADDRESS_ID_INVALID, &names, NULL, peer->policy->seclabel, NULL, message);
+                                                   peer->id, ADDRESS_ID_INVALID, &names, NULL, peer->policy->seclabel, peer->bus->seclabel, message);
                         r = log_commitf(peer->bus->log, "A security policy denied :1.%llu to send method call %s:%s.%s to org.freedesktop.DBus.",
                                         peer->id, path, interface, member);
                         if (r)

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -709,10 +709,22 @@ int peer_queue_reply(Peer *sender, const char *destination, uint32_t reply_seria
 
         r = connection_queue(&receiver->connection, NULL, message);
         if (r) {
-                if (r == CONNECTION_E_QUOTA)
+                if (r == CONNECTION_E_QUOTA) {
+                        NameSet sender_names = NAME_SET_INIT_FROM_OWNER(&sender->owned_names);
+                        NameSet receiver_names = NAME_SET_INIT_FROM_OWNER(&receiver->owned_names);
+
                         connection_shutdown(&receiver->connection);
-                else
+
+                        log_append_here(receiver->bus->log, LOG_WARNING, 0);
+                        bus_log_append_transaction(receiver->bus, sender->id, receiver->id, &sender_names, &receiver_names,
+                                                   sender->policy->seclabel, receiver->policy->seclabel, message);
+                        r = log_commitf(receiver->bus->log, "Peer :1.%llu is being disconnected as it does not have the resources to receive a reply it requested.",
+                                        receiver->id);
+                        if (r)
+                                return error_fold(r);
+                } else {
                         return error_fold(r);
+                }
         }
 
         return 0;

--- a/src/util/test-user.c
+++ b/src/util/test-user.c
@@ -11,7 +11,7 @@ static void test_setup(void) {
         User *entry1, *entry2, *entry3;
         int r;
 
-        r = user_registry_init(&registry, _USER_SLOT_N, (unsigned int[]){ 1024, 1024, 1024, 1024, 1024 });
+        r = user_registry_init(&registry, NULL, _USER_SLOT_N, (unsigned int[]){ 1024, 1024, 1024, 1024, 1024 });
         assert(!r);
 
         r = user_registry_ref_user(&registry, &entry1, 1);
@@ -38,7 +38,7 @@ static void test_quota(void) {
         UserCharge charge1, charge2, charge3;
         int r;
 
-        r = user_registry_init(&registry, _USER_SLOT_N, (unsigned int[]){ 1024, 1024, 1024, 1024, 1024 });
+        r = user_registry_init(&registry, NULL, _USER_SLOT_N, (unsigned int[]){ 1024, 1024, 1024, 1024, 1024 });
         assert(!r);
 
         r = user_registry_ref_user(&registry, &entry1, 1);

--- a/src/util/user.h
+++ b/src/util/user.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
+typedef struct Log Log;
 typedef struct UserCharge UserCharge;
 typedef struct UserUsage UserUsage;
 typedef struct User User;
@@ -23,6 +24,21 @@ enum {
         USER_SLOT_OBJECTS,
         _USER_SLOT_N,
 };
+
+static inline const char *user_slot_to_string(size_t slot) {
+        switch (slot) {
+        case USER_SLOT_BYTES:
+                return "bytes";
+        case USER_SLOT_FDS:
+                return "FDs";
+        case USER_SLOT_MATCHES:
+                return "matches";
+        case USER_SLOT_OBJECTS:
+                return "objects";
+        default:
+                assert(0);
+        }
+}
 
 enum {
         _USER_E_SUCCESS,
@@ -66,6 +82,7 @@ int user_charge(User *user, UserCharge *charge, User *actor, size_t slot, unsign
 /* registry */
 
 struct UserRegistry {
+        Log *log;
         CRBTree user_tree;
         size_t n_slots;
         unsigned int *maxima;
@@ -75,7 +92,7 @@ struct UserRegistry {
                 .user_tree = C_RBTREE_INIT,                                     \
         }
 
-int user_registry_init(UserRegistry *registry, size_t n_slots, const unsigned int *maxima);
+int user_registry_init(UserRegistry *registry, Log *log, size_t n_slots, const unsigned int *maxima);
 void user_registry_deinit(UserRegistry *registry);
 int user_registry_ref_user(UserRegistry *registry, User **userp, uid_t uid);
 


### PR DESCRIPTION
Make sure we log about all quota failures. Also, log about failing transactions due to quota failure (separately). Together this should make debugging considerably simpler.

There are still cases where clients are disconnected which are not logged, namely where the peer has exceeded its own quota or attempts a protocol violation. These should be addressed separately, as they are more complicated to get right, and less likely to crop up in real life.

Calling org.freedesktop.DBus.GetId on org.freedesktop.DBus in a loop without reading the replies now logs about the resulting disconnect as follows:

```
UID 1000 exceeded its 'bytes' quota on UID 1000.
Peer :1.107 is being disconnected as it does not have the resources to receive a reply or unicast signal it expects.
```