### PR TITLE
match/iterator: replace iterators with getters for destinations

### DIFF
--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -91,13 +91,11 @@ static int bus_get_monitor_destinations_for_matches(CList *destinations, MatchRe
         MatchRule *rule;
 
         for (rule = match_rule_next_monitor_match(matches, NULL, metadata); rule; rule = match_rule_next_monitor_match(matches, rule, metadata)) {
-                Peer *receiver = c_container_of(rule->owner, Peer, owned_matches);
-
-                if (c_list_is_linked(&receiver->destinations_link))
+                if (c_list_is_linked(&rule->owner->destinations_link))
                         /* only link a destination once, despite matching in several different ways */
                         continue;
 
-                c_list_link_tail(destinations, &receiver->destinations_link);
+                c_list_link_tail(destinations, &rule->owner->destinations_link);
         }
 
         return 0;
@@ -142,13 +140,11 @@ static int bus_get_broadcast_destinations_for_matches(CList *destinations, Match
         MatchRule *rule;
 
         for (rule = match_rule_next_subscription_match(matches, NULL, metadata); rule; rule = match_rule_next_subscription_match(matches, rule, metadata)) {
-                Peer *receiver = c_container_of(rule->owner, Peer, owned_matches);
-
-                if (c_list_is_linked(&receiver->destinations_link))
+                if (c_list_is_linked(&rule->owner->destinations_link))
                         /* only link a destination once, despite matching in several different ways */
                         continue;
 
-                c_list_link_tail(destinations, &receiver->destinations_link);
+                c_list_link_tail(destinations, &rule->owner->destinations_link);
         }
 
         return 0;

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -70,8 +70,8 @@ int bus_init(Bus *bus,
 void bus_deinit(Bus *bus);
 
 Peer *bus_find_peer_by_name(Bus *bus, Name **namep, const char *name);
-int bus_get_monitor_destinations(Bus *bus, CList *destinations, Peer *sender, MessageMetadata *metadata);
-int bus_get_broadcast_destinations(Bus *bus, CList *destinations, MatchRegistry *matches, Peer *sender, MessageMetadata *metadata);
+void bus_get_monitor_destinations(Bus *bus, CList *destinations, Peer *sender, MessageMetadata *metadata);
+void bus_get_broadcast_destinations(Bus *bus, CList *destinations, MatchRegistry *matches, Peer *sender, MessageMetadata *metadata);
 
 void bus_log_append_policy_send(Bus *bus, int policy_type, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receiver_names, const char *sender_label, const char *receiver_label, Message *message);
 void bus_log_append_policy_receive(Bus *bus, uint64_t sender_id, uint64_t receiver_id, NameSet *sender_names, NameSet *receievr_names, Message *message);

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -339,9 +339,7 @@ static int driver_monitor(Bus *bus, Peer *sender, Message *message) {
         if (r)
                 return error_fold(r);
 
-        r = bus_get_monitor_destinations(bus, &destinations, sender, &message->metadata);
-        if (r)
-                return error_trace(r);
+        bus_get_monitor_destinations(bus, &destinations, sender, &message->metadata);
 
         while ((match_owner = c_list_first_entry(&destinations, MatchOwner, destinations_link))) {
                 Peer *receiver = c_container_of(match_owner, Peer, owned_matches);
@@ -564,13 +562,8 @@ static int driver_notify_name_owner_changed(Bus *bus, MatchRegistry *matches, co
         };
         int r;
 
-        r = bus_get_monitor_destinations(bus, &destinations, NULL, &metadata);
-        if (r)
-                return error_trace(r);
-
-        r = bus_get_broadcast_destinations(bus, &destinations, matches, NULL, &metadata);
-        if (r)
-                return error_trace(r);
+        bus_get_monitor_destinations(bus, &destinations, NULL, &metadata);
+        bus_get_broadcast_destinations(bus, &destinations, matches, NULL, &metadata);
 
         if (!c_list_is_empty(&destinations)) {
                 static const CDVarType type[] = {
@@ -2094,9 +2087,7 @@ static int driver_forward_broadcast(Peer *sender, Message *message) {
         MatchOwner *match_owner;
         int r;
 
-        r = bus_get_broadcast_destinations(sender->bus, &destinations, &sender->sender_matches, sender, &message->metadata);
-        if (r)
-                return error_trace(r);
+        bus_get_broadcast_destinations(sender->bus, &destinations, &sender->sender_matches, sender, &message->metadata);
 
         while ((match_owner = c_list_first_entry(&destinations, MatchOwner, destinations_link))) {
                 Peer *receiver = c_container_of(match_owner, Peer, owned_matches);

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -1031,7 +1031,7 @@ MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rul
  * match_owner_init() - XXX
  */
 void match_owner_init(MatchOwner *owner) {
-        *owner = (MatchOwner)MATCH_OWNER_INIT;
+        *owner = (MatchOwner)MATCH_OWNER_INIT(*owner);
 }
 
 /**
@@ -1039,6 +1039,7 @@ void match_owner_init(MatchOwner *owner) {
  */
 void match_owner_deinit(MatchOwner *owner) {
         assert(c_rbtree_is_empty(&owner->rule_tree));
+        assert(!c_list_is_linked(&owner->destinations_link));
 }
 
 /**

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -1019,11 +1019,11 @@ static MatchRule *match_rule_next_match(CRBTree *tree, MatchRule *rule, MessageM
         return rule;
 }
 
-MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata) {
+static MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata) {
         return match_rule_next_match(&registry->subscription_tree, rule, metadata);
 }
 
-MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata) {
+static MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata) {
         return match_rule_next_match(&registry->monitor_tree, rule, metadata);
 }
 

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -1108,6 +1108,30 @@ void match_registry_deinit(MatchRegistry *registry) {
         assert(c_rbtree_is_empty(&registry->monitor_tree));
 }
 
+void match_registry_get_subscribers(MatchRegistry *matches, CList *destinations, MessageMetadata *metadata) {
+        MatchRule *rule;
+
+        for (rule = match_rule_next_subscription_match(matches, NULL, metadata); rule; rule = match_rule_next_subscription_match(matches, rule, metadata)) {
+                if (c_list_is_linked(&rule->owner->destinations_link))
+                        /* only link a destination once, despite matching in several different ways */
+                        continue;
+
+                c_list_link_tail(destinations, &rule->owner->destinations_link);
+        }
+}
+
+void match_registry_get_monitors(MatchRegistry *matches, CList *destinations, MessageMetadata *metadata) {
+        MatchRule *rule;
+
+        for (rule = match_rule_next_monitor_match(matches, NULL, metadata); rule; rule = match_rule_next_monitor_match(matches, rule, metadata)) {
+                if (c_list_is_linked(&rule->owner->destinations_link))
+                        /* only link a destination once, despite matching in several different ways */
+                        continue;
+
+                c_list_link_tail(destinations, &rule->owner->destinations_link);
+        }
+}
+
 static void match_registry_by_keys_flush(MatchRegistryByKeys *registry) {
         MatchRule *rule, *rule_safe;
 

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -1002,7 +1002,7 @@ static void match_registry_by_keys_get_destinations(MatchRegistryByKeys *registr
 static void match_registry_by_member_get_destinations(MatchRegistryByMember *registry, CList *destinations, MessageMetadata *metadata) {
         MatchRegistryByKeys *registry_by_keys;
 
-        c_rbtree_for_each_entry(registry_by_keys, &registry->keys_tree, registry_node) {
+        c_rbtree_for_each_entry_postorder(registry_by_keys, &registry->keys_tree, registry_node) {
                 if (!match_keys_match_metadata(&registry_by_keys->keys, metadata))
                         continue;
 

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -85,10 +85,12 @@ struct MatchRule {
 
 struct MatchOwner {
         CRBTree rule_tree;
+        CList destinations_link;
 };
 
-#define MATCH_OWNER_INIT {                      \
-                .rule_tree = C_RBTREE_INIT,     \
+#define MATCH_OWNER_INIT(_x) {                                                  \
+                .rule_tree = C_RBTREE_INIT,                                     \
+                .destinations_link = C_LIST_INIT((_x).destinations_link),       \
         }
 
 struct MatchRegistryByKeys {

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -187,4 +187,7 @@ int match_owner_find_rule(MatchOwner *owner, MatchRule **rulep, const char *rule
 void match_registry_init(MatchRegistry *registry);
 void match_registry_deinit(MatchRegistry *registry);
 
+void match_registry_get_subscribers(MatchRegistry *matches, CList *destinations, MessageMetadata *metadata);
+void match_registry_get_monitors(MatchRegistry *matches, CList *destinations, MessageMetadata *metadata);
+
 void match_registry_flush(MatchRegistry *registry);

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -168,9 +168,6 @@ MatchRule *match_rule_user_unref(MatchRule *rule);
 int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor);
 void match_rule_unlink(MatchRule *rule);
 
-MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata);
-MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata);
-
 C_DEFINE_CLEANUP(MatchRule *, match_rule_user_unref);
 
 /* owners */

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -75,8 +75,6 @@ struct Peer {
         MatchOwner owned_matches;
         ReplyRegistry replies;
         ReplyOwner owned_replies;
-
-        CList destinations_link;
 };
 
 #define PEER_INIT(_x) {                                                                                 \
@@ -89,10 +87,9 @@ struct Peer {
                 .owned_names = NAME_OWNER_INIT,                                                         \
                 .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),                             \
                 .name_owner_changed_matches = MATCH_REGISTRY_INIT((_x).name_owner_changed_matches),     \
-                .owned_matches = MATCH_OWNER_INIT,                                                      \
+                .owned_matches = MATCH_OWNER_INIT((_x).owned_matches),                                  \
                 .replies = REPLY_REGISTRY_INIT,                                                         \
                 .owned_replies = REPLY_OWNER_INIT((_x).owned_replies),                                  \
-                .destinations_link = C_LIST_INIT((_x).destinations_link),                               \
         }
 
 struct PeerRegistry {

--- a/src/bus/test-match.c
+++ b/src/bus/test-match.c
@@ -310,7 +310,7 @@ static void test_iterator(void) {
 }
 
 int main(int argc, char **argv) {
-        MatchOwner owner = {};
+        MatchOwner owner = MATCH_OWNER_INIT(owner);
 
         test_splitting(&owner);
         test_parse_key(&owner);


### PR DESCRIPTION
This simplifies the code, and keeps anything not match-related (policy decisions) in the caller. It marginally improves the worst case performance, but to avoid the O(n) worst-case performance, we would need to introduce Bloom filters, so optimizing this further does not seem worth the effort.