### PR TITLE
Treat directed signals like method calls without replies

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -722,7 +722,7 @@ static int driver_name_activated(Activation *activation, Peer *receiver) {
 
                 sender = peer_registry_find_peer(&receiver->bus->peers, message->message->metadata.sender_id);
 
-                r = peer_queue_call(message->senders_policy, &sender_names, sender ? &sender->owned_replies : NULL, message->user, message->message->metadata.sender_id, receiver, message->message);
+                r = peer_queue_unicast(message->senders_policy, &sender_names, sender ? &sender->owned_replies : NULL, message->user, message->message->metadata.sender_id, receiver, message->message);
                 if (r) {
                         switch (r) {
                         case PEER_E_QUOTA:
@@ -2054,7 +2054,7 @@ static int driver_forward_unicast(Peer *sender, const char *destination, Message
                 return 0;
         }
 
-        r = peer_queue_call(sender->policy, &sender_names, &sender->owned_replies, sender->user, sender->id, receiver, message);
+        r = peer_queue_unicast(sender->policy, &sender_names, &sender->owned_replies, sender->user, sender->id, receiver, message);
         if (r) {
                 if (r == PEER_E_EXPECTED_REPLY_EXISTS)
                         return DRIVER_E_EXPECTED_REPLY_EXISTS;

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -906,10 +906,6 @@ void match_rule_unlink(MatchRule *rule) {
         }
 }
 
-bool match_rule_match_metadata(MatchRule *rule, MessageMetadata *metadata) {
-        return match_keys_match_metadata(&rule->keys, metadata);
-}
-
 static MatchRule *match_rule_next_match_by_keys(MatchRegistryByKeys *registry, MatchRule *rule) {
         c_list_for_each_entry_continue(rule, &registry->rule_list, registry_link)
                 return rule;

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -166,8 +166,6 @@ MatchRule *match_rule_user_unref(MatchRule *rule);
 int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor);
 void match_rule_unlink(MatchRule *rule);
 
-bool match_rule_match_metadata(MatchRule *rule, MessageMetadata *metadata);
-
 MatchRule *match_rule_next_subscription_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata);
 MatchRule *match_rule_next_monitor_match(MatchRegistry *registry, MatchRule *rule, MessageMetadata *metadata);
 

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -628,7 +628,7 @@ static bool peer_message_is_solicited(Peer *destination, uint64_t sender_id, Mes
         return false;
 }
 
-int peer_queue_call(PolicySnapshot *sender_policy, NameSet *sender_names, ReplyOwner *sender_replies, User *sender_user, uint64_t sender_id, Peer *receiver, Message *message) {
+int peer_queue_unicast(PolicySnapshot *sender_policy, NameSet *sender_names, ReplyOwner *sender_replies, User *sender_user, uint64_t sender_id, Peer *receiver, Message *message) {
         _c_cleanup_(reply_slot_freep) ReplySlot *slot = NULL;
         NameSet receiver_names = NAME_SET_INIT_FROM_OWNER(&receiver->owned_names);
         uint32_t serial;

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -123,7 +123,7 @@ int peer_become_monitor(Peer *peer, MatchOwner *owner);
 void peer_stop_monitor(Peer *peer);
 void peer_flush_matches(Peer *peer);
 
-int peer_queue_call(PolicySnapshot *sender_policy, NameSet *sender_names, ReplyOwner *sender_replies, User *sender_user, uint64_t sender_id, Peer *receiver, Message *message);
+int peer_queue_unicast(PolicySnapshot *sender_policy, NameSet *sender_names, ReplyOwner *sender_replies, User *sender_user, uint64_t sender_id, Peer *receiver, Message *message);
 int peer_queue_reply(Peer *sender, const char *destination, uint32_t reply_serial, Message *message);
 
 void peer_registry_init(PeerRegistry *registry);


### PR DESCRIPTION
This only affects the case when the message transaction fails due to resource exhaustion. It used to be that if the receiver had a matching match installed they would be disconnected (treated as a solicited message). However, this semantics is not standardised, and installing matches for directed matches is not common practice.

Simplify the semantics by treating a directed signal just like a method call with the REPLY_NOT_EXPECTED flag set. This means that if the message could not be delivered it is dropped. This essentially implies that directed signals are recommended against if you want your client to be robust.