### PR TITLE
apparmor: add skeleton support

### DIFF
--- a/src/bus/policy.c
+++ b/src/bus/policy.c
@@ -503,6 +503,7 @@ static int policy_registry_import_batch(PolicyRegistry *registry,
  */
 int policy_registry_import(PolicyRegistry *registry, CDVar *v) {
         PolicyRegistryNode *node;
+        bool apparmor;
         int r;
 
         /* XXX: provide the type */
@@ -572,7 +573,13 @@ int policy_registry_import(PolicyRegistry *registry, CDVar *v) {
                         return error_fold(r);
         }
 
-        c_dvar_read(v, "])>");
+        c_dvar_read(v, "]b", &apparmor);
+
+        if (apparmor)
+                /* XXX: AppArmor is currently not supported. */
+                return POLICY_E_INVALID;
+
+        c_dvar_read(v, ")>");
 
         r = c_dvar_get_poison(v);
         if (r)

--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -605,6 +605,12 @@ static int policy_import_selinux(Policy *policy, ConfigNode *cnode) {
         return 0;
 }
 
+static int policy_import_apparmor(Policy *policy, ConfigNode *cnode) {
+        policy->apparmor_mode = cnode->apparmor.mode;
+
+        return 0;
+}
+
 /**
  * policy_import() - XXX
  */
@@ -619,6 +625,13 @@ int policy_import(Policy *policy, ConfigRoot *root) {
         c_list_for_each_entry(i_cnode, &root->node_list, root_link) {
                 if (i_cnode->type == CONFIG_NODE_ASSOCIATE) {
                         r = policy_import_selinux(policy, i_cnode);
+                        if (r)
+                                return error_trace(r);
+                        continue;
+                }
+
+                if (i_cnode->type == CONFIG_NODE_APPARMOR) {
+                        r = policy_import_apparmor(policy, i_cnode);
                         if (r)
                                 return error_trace(r);
                         continue;
@@ -885,7 +898,8 @@ static int policy_export_xmit(Policy *policy, CList *list1, CList *list2, sd_bus
 #define POLICY_T                                                                \
                 "a(u(" POLICY_T_BATCH "))"                                      \
                 "a(buu(" POLICY_T_BATCH "))"                                    \
-                "a(ss)"
+                "a(ss)"                                                         \
+                "b"
 
 static int policy_export_console(Policy *policy, sd_bus_message *m, PolicyEntries *entries, uint32_t uid_start, uint32_t n_uid) {
         int r;
@@ -1099,6 +1113,10 @@ int policy_export(Policy *policy, sd_bus_message *m, uint32_t *at_console_uids, 
         }
 
         r = sd_bus_message_close_container(m);
+        if (r < 0)
+                return error_origin(r);
+
+        r = sd_bus_message_append(m, "b", (policy->apparmor_mode != CONFIG_APPARMOR_DISABLED));
         if (r < 0)
                 return error_origin(r);
 

--- a/src/launch/policy.h
+++ b/src/launch/policy.h
@@ -99,6 +99,7 @@ struct Policy {
         CRBTree gid_tree;
 
         CList selinux_list;
+        unsigned int apparmor_mode;
 };
 
 #define POLICY_INIT(_x) {                                                               \
@@ -108,7 +109,8 @@ struct Policy {
                 .no_console_entries = POLICY_ENTRIES_NULL((_x).no_console_entries),     \
                 .uid_tree = C_RBTREE_INIT,                                              \
                 .gid_tree = C_RBTREE_INIT,                                              \
-                .selinux_list = C_LIST_INIT((_x).selinux_list)                          \
+                .selinux_list = C_LIST_INIT((_x).selinux_list),                         \
+                .apparmor_mode = CONFIG_APPARMOR_ENABLED,                               \
         }
 
 /* records */

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ sources_bus = [
         'dbus/queue.c',
         'dbus/sasl.c',
         'dbus/socket.c',
+        'util/apparmor.c',
         'util/error.c',
         'util/dispatch.c',
         'util/fdlist.c',
@@ -151,6 +152,9 @@ endif
 
 test_address = executable('test-address', ['dbus/test-address.c'], dependencies: dep_bus)
 test('Address Handling', test_address)
+
+test_apparmor = executable('test-apparmor', ['util/test-apparmor.c'], dependencies: dep_bus)
+test('AppArmor Handling', test_apparmor)
 
 test_config = executable('test-config', ['launch/test-config.c'], dependencies: dep_bus)
 test('Configuration Parser', test_config)

--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -1,0 +1,58 @@
+/*
+ * Bus AppArmor Helpers
+ *
+ * AppArmor support is not implemented upstream in dbus-broker, as the
+ * required kernel infrastructure is not yet upstream in the kernel.
+ *
+ * We just do the bare minimum of refusing to start if AppArmor is
+ * configured to be required, and to warn if support is enabled in
+ * the kernel, and AppArmor is configured to be enabled by the
+ * applicable policy.
+ */
+
+#include <c-macro.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "util/apparmor.h"
+#include "util/error.h"
+
+/** bus_apparmor_is_enabled() - checks if AppArmor is currently enabled
+ * @enabled:            return argument telling if AppArmor is enabled
+ *
+ * If the AppArmor module is not loaded, or AppArmor is disabled in the
+ * kernel, set @enabledp to 'false', otherwise set it to 'true'.
+ *
+ * Returns: 0 if check succeeded, or negative error code on failure.
+ */
+int bus_apparmor_is_enabled(bool *enabledp) {
+        _c_cleanup_(c_fclosep) FILE *f = NULL;
+        char buffer[LINE_MAX] = {};
+        bool enabled;
+
+        f = fopen("/sys/module/apparmor/parameters/enabled", "re");
+        if (f) {
+                errno = 0;
+                if (!fgets(buffer, sizeof(buffer), f)) {
+                        if (ferror(f) && errno != EINVAL)
+                                return errno ? error_origin(-errno) : error_origin(-ENOTRECOVERABLE);
+                }
+
+                switch (buffer[0]) {
+                        case 'Y':
+                                enabled = true;
+                                break;
+                        case 'N':
+                                enabled = false;
+                                break;
+                        default:
+                                return error_origin(-EIO);
+                }
+        } else if (errno == ENOENT) {
+                enabled = false;
+        } else {
+                return error_origin(-errno);
+        }
+
+        *enabledp = enabled;
+        return 0;
+}

--- a/src/util/apparmor.h
+++ b/src/util/apparmor.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/*
+ * Bus AppArmor Helpers
+ */
+
+#include <stdlib.h>
+
+int bus_apparmor_is_enabled(bool *enabledp);

--- a/src/util/test-apparmor.c
+++ b/src/util/test-apparmor.c
@@ -1,0 +1,20 @@
+/*
+ * Test AppArmor Handling
+ */
+
+#include <c-macro.h>
+#include <stdlib.h>
+#include "util/apparmor.h"
+
+static void test_basic(void) {
+        bool enabled;
+        int r;
+
+        r = bus_apparmor_is_enabled(&enabled);
+        assert(!r);
+}
+
+int main(int argc, char **argv) {
+        test_basic();
+        return 0;
+}

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -54,7 +54,8 @@ static int util_event_sigchld(sd_event_source *source, const siginfo_t *si, void
 #define POLICY_T                                                                \
                 "a(u(" POLICY_T_BATCH "))"                                      \
                 "a(buu(" POLICY_T_BATCH "))"                                    \
-                "a(ss)"
+                "a(ss)"                                                         \
+                "b"
 
 static int util_append_policy(sd_bus_message *m) {
         int r;
@@ -120,6 +121,12 @@ static int util_append_policy(sd_bus_message *m) {
                 assert(r >= 0);
 
                 r = sd_bus_message_close_container(m);
+                assert(r >= 0);
+        }
+
+        /* disable AppArmor */
+        {
+                r = sd_bus_message_append(m, "b", false);
                 assert(r >= 0);
         }
 


### PR DESCRIPTION
The intention with this patch is to make it simple to carry a downstream patch in case a distribution wants AppArmor support and carries the required downstream kernel patches too.

So far only the `mode="required"` has been tested to verify that it correctly shuts down the broker on config reload and then refuses to restart.