### PR TITLE
policy: implement send_broadcast, min_fds and max_fds parameters

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -630,7 +630,9 @@ static int driver_notify_name_owner_changed(Bus *bus, MatchRegistry *matches, co
                                                           metadata.fields.interface,
                                                           metadata.fields.member,
                                                           metadata.fields.path,
-                                                          metadata.header.type);
+                                                          metadata.header.type,
+                                                          true,
+                                                          0);
                         if (r) {
                                 if (r == POLICY_E_ACCESS_DENIED)
                                         continue;
@@ -1978,7 +1980,7 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
                 /* ignore */
                 return 0;
 
-        r = policy_snapshot_check_send(peer->policy, NULL, NULL, interface, member, path, message->header->type);
+        r = policy_snapshot_check_send(peer->policy, NULL, NULL, interface, member, path, message->header->type, false, message->metadata.fields.unix_fds);
         if (r) {
                 if (r == POLICY_E_ACCESS_DENIED || r == POLICY_E_SELINUX_ACCESS_DENIED) {
                         NameSet names = NAME_SET_INIT_FROM_OWNER(&peer->owned_names);
@@ -2135,7 +2137,9 @@ static int driver_forward_broadcast(Peer *sender, Message *message) {
                                                message->metadata.fields.interface,
                                                message->metadata.fields.member,
                                                message->metadata.fields.path,
-                                               message->metadata.header.type);
+                                               message->metadata.header.type,
+                                               true,
+                                               message->metadata.fields.unix_fds);
                 if (r) {
                         if (r == POLICY_E_ACCESS_DENIED || r == POLICY_E_SELINUX_ACCESS_DENIED)
                                 continue;
@@ -2148,7 +2152,9 @@ static int driver_forward_broadcast(Peer *sender, Message *message) {
                                                   message->metadata.fields.interface,
                                                   message->metadata.fields.member,
                                                   message->metadata.fields.path,
-                                                  message->metadata.header.type);
+                                                  message->metadata.header.type,
+                                                  true,
+                                                  message->metadata.fields.unix_fds);
                 if (r) {
                         if (r == POLICY_E_ACCESS_DENIED)
                                 continue;

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -632,7 +632,9 @@ int peer_queue_unicast(PolicySnapshot *sender_policy, NameSet *sender_names, Rep
                                           message->metadata.fields.interface,
                                           message->metadata.fields.member,
                                           message->metadata.fields.path,
-                                          message->header->type);
+                                          message->header->type,
+                                          false,
+                                          message->metadata.fields.unix_fds);
         if (r) {
                 if (r == POLICY_E_ACCESS_DENIED) {
                         log_append_here(receiver->bus->log, LOG_WARNING, 0);
@@ -657,7 +659,9 @@ int peer_queue_unicast(PolicySnapshot *sender_policy, NameSet *sender_names, Rep
                                        message->metadata.fields.interface,
                                        message->metadata.fields.member,
                                        message->metadata.fields.path,
-                                       message->header->type);
+                                       message->header->type,
+                                       false,
+                                       message->metadata.fields.unix_fds);
         if (r) {
                 if (r == POLICY_E_ACCESS_DENIED || r == POLICY_E_SELINUX_ACCESS_DENIED) {
                         log_append_here(receiver->bus->log, LOG_WARNING, 0);

--- a/src/bus/policy.h
+++ b/src/bus/policy.h
@@ -43,15 +43,19 @@ struct PolicyXmit {
         CList batch_link;
         PolicyVerdict verdict;
         unsigned int type;
+        unsigned int broadcast;
         char *path;
         char *interface;
         char *member;
+        uint64_t min_fds;
+        uint64_t max_fds;
 };
 
 #define POLICY_XMIT_NULL(_x) {                                                  \
                 .batch_link = C_LIST_INIT((_x).batch_link),                     \
                 .verdict = POLICY_VERDICT_INIT,                                 \
                 .type = DBUS_MESSAGE_TYPE_INVALID,                              \
+                .max_fds = UINT64_MAX,                                          \
         }
 
 struct PolicyBatchName {
@@ -163,13 +167,17 @@ int policy_snapshot_check_send(PolicySnapshot *snapshot,
                                const char *interface,
                                const char *method,
                                const char *path,
-                               unsigned int type);
+                               unsigned int type,
+                               bool broadcast,
+                               size_t n_fds);
 int policy_snapshot_check_receive(PolicySnapshot *snapshot,
                                   NameSet *subject,
                                   const char *interface,
                                   const char *method,
                                   const char *path,
-                                  unsigned int type);
+                                  unsigned int type,
+                                  bool broadcast,
+                                  size_t n_fds);
 
 C_DEFINE_CLEANUP(PolicySnapshot *, policy_snapshot_free);
 

--- a/src/dbus/message.c
+++ b/src/dbus/message.c
@@ -608,10 +608,12 @@ void message_log_append(Message *message, Log *log) {
         log_appendf(log,
                     "DBUS_BROKER_MESSAGE_DESTINATION=%s\n"
                     "DBUS_BROKER_MESSAGE_SERIAL=%"PRIu32"\n"
-                    "DBUS_BROKER_MESSAGE_SIGNATURE=%s\n",
+                    "DBUS_BROKER_MESSAGE_SIGNATURE=%s\n"
+                    "DBUS_BROKER_MESSAGE_UNIX_FDS=%"PRIu32"\n",
                     message->metadata.fields.destination ?: "<broadcast>",
                     message->metadata.header.serial,
-                    message->metadata.fields.signature ?: "<missing>");
+                    message->metadata.fields.signature ?: "<missing>",
+                    message->metadata.fields.unix_fds);
 
         switch (message->metadata.header.type) {
         case DBUS_MESSAGE_TYPE_METHOD_CALL:

--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -25,12 +25,6 @@ enum {
 };
 
 enum {
-        CONFIG_TRISTATE_UNSET,
-        CONFIG_TRISTATE_YES,
-        CONFIG_TRISTATE_NO,
-};
-
-enum {
         CONFIG_NODE_NONE,
 
         CONFIG_NODE_BUSCONFIG,
@@ -146,12 +140,15 @@ struct ConfigNode {
                         char *send_destination;
                         char *send_path;
                         unsigned int send_type;
+                        unsigned int send_broadcast;
                         char *recv_interface;
                         char *recv_member;
                         char *recv_error;
                         char *recv_sender;
                         char *recv_path;
                         unsigned int recv_type;
+                        uint64_t min_fds;
+                        uint64_t max_fds;
                         char *own;
                         char *own_prefix;
                         uint32_t uid;

--- a/src/launch/policy.h
+++ b/src/launch/policy.h
@@ -36,6 +36,9 @@ struct PolicyRecord {
                         const char *interface;
                         const char *member;
                         unsigned int type;
+                        unsigned int broadcast;
+                        uint64_t min_fds;
+                        uint64_t max_fds;
                 } xmit;
 
                 struct {

--- a/src/util/common.h
+++ b/src/util/common.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/**
+ * Common definitions and helpers.
+ */
+
+#include <stdlib.h>
+
+enum {
+        UTIL_TRISTATE_UNSET,
+        UTIL_TRISTATE_YES,
+        UTIL_TRISTATE_NO,
+
+        _N_UTIL_TRISTATE,
+};
+

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -48,8 +48,8 @@ static int util_event_sigchld(sd_event_source *source, const siginfo_t *si, void
 #define POLICY_T_BATCH                                                          \
                 "bt"                                                            \
                 "a(btbs)"                                                       \
-                "a(btssssu)"                                                    \
-                "a(btssssu)"
+                "a(btssssuutt)"                                                 \
+                "a(btssssuutt)"
 
 #define POLICY_T                                                                \
                 "a(u(" POLICY_T_BATCH "))"                                      \
@@ -88,11 +88,11 @@ static int util_append_policy(sd_bus_message *m) {
                  *  - allow all recvs
                  */
                 r = sd_bus_message_append(m,
-                                          "bt" "a(btbs)" "a(btssssu)" "a(btssssu)",
+                                          "bt" "a(btbs)" "a(btssssuutt)" "a(btssssuutt)",
                                           true, UINT64_C(1),
                                           1, true, UINT64_C(1), true, "",
-                                          1, true, UINT64_C(1), "", "", "", "", 0,
-                                          1, true, UINT64_C(1), "", "", "", "", 0);
+                                          1, true, UINT64_C(1), "", "", "", "", 0, 0, UINT64_C(0), UINT64_MAX,
+                                          1, true, UINT64_C(1), "", "", "", "", 0, 0, UINT64_C(0), UINT64_MAX);
                 assert(r >= 0);
 
                 r = sd_bus_message_close_container(m);


### PR DESCRIPTION
Internally, the implementation is symmetric, allowing recv_broadcast to
be supported too. However, that is not supported by the policy language,
nor the parser.

Also, extend the message logging to include the number of file descriptors,
as that can now influence policy decisions.

Signed-off-by: Tom Gundersen <teg@jklm.no>