### PR TITLE
Gracefully handle ReloadConfig and SIGHUP when the config is invalid

### DIFF
--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -148,6 +148,13 @@ int controller_reload_completed(ControllerReload *reload) {
         return error_fold(driver_reload_config_completed(&reload->controller->broker->bus, reload->sender_id, reload->sender_serial));
 }
 
+/**
+ * controller_reload_invalid() - XXX
+ */
+int controller_reload_invalid(ControllerReload *reload) {
+        return error_fold(driver_reload_config_invalid(&reload->controller->broker->bus, reload->sender_id, reload->sender_serial));
+}
+
 static int controller_listener_compare(CRBTree *t, void *k, CRBNode *rb) {
         ControllerListener *listener = c_container_of(rb, ControllerListener, controller_node);
 

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -263,6 +263,10 @@ int controller_init(Controller *c, Broker *broker, int controller_fd) {
 void controller_deinit(Controller *controller) {
         ControllerListener *listener, *listener_safe;
         ControllerName *name, *name_safe;
+        ControllerReload *reload, *reload_safe;
+
+        c_rbtree_for_each_entry_safe_postorder_unlink(reload, reload_safe, &controller->reload_tree, controller_node)
+                controller_reload_free(reload);
 
         c_rbtree_for_each_entry_safe_postorder_unlink(name, name_safe, &controller->name_tree, controller_node)
                 controller_name_free(name);

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -40,6 +40,7 @@ enum {
         CONTROLLER_E_UNEXPECTED_METHOD,
         CONTROLLER_E_UNEXPECTED_SIGNATURE,
         CONTROLLER_E_UNEXPECTED_REPLY,
+        CONTROLLER_E_UNEXPECTED_ERROR,
 
         CONTROLLER_E_LISTENER_EXISTS,
         CONTROLLER_E_LISTENER_INVALID_FD,
@@ -115,6 +116,7 @@ C_DEFINE_CLEANUP(ControllerListener *, controller_listener_free);
 /* reload */
 ControllerReload *controller_reload_free(ControllerReload *reload);
 int controller_reload_completed(ControllerReload *reload);
+int controller_reload_invalid(ControllerReload *reload);
 
 C_DEFINE_CLEANUP(ControllerReload *, controller_reload_free);
 

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1472,6 +1472,20 @@ int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_
         return 0;
 }
 
+int driver_reload_config_invalid(Bus *bus, uint64_t sender_id, uint32_t reply_serial) {
+        Peer *sender;
+        int r;
+
+        sender = peer_registry_find_peer(&bus->peers, sender_id);
+        if (sender) {
+                r = driver_send_error(sender, reply_serial, "org.freedesktop.DBus.Error.Failed", "Config invalid. Reload ignored.");
+                if (r)
+                        return error_trace(r);
+        }
+
+        return 0;
+}
+
 static int driver_method_reload_config(Peer *peer, CDVar *in_v, uint32_t serial, CDVar *out_v) {
         int r;
 

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -66,6 +66,7 @@ enum {
 
 int driver_name_activation_failed(Bus *bus, Activation *activation);
 int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
+int driver_reload_config_invalid(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 
 int driver_dispatch(Peer *peer, Message *message);
 int driver_goodbye(Peer *peer, bool silent);

--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -1188,7 +1188,7 @@ static int config_parser_include(ConfigParser *parser, ConfigRoot *root, ConfigN
         r = open(node->include.file->path, O_RDONLY | O_CLOEXEC | O_NOCTTY);
         if (r < 0) {
                 if (errno == ENOENT || errno == ENOTDIR)
-                        return node->include.ignore_missing ? 0 : error_origin(-errno);
+                        return node->include.ignore_missing ? 0 : CONFIG_E_INVALID;
 
                 return error_origin(-errno);
         }


### PR DESCRIPTION
Make sure we don't trigger a hard failure, but refuse to load invalid config. We may want to audit the config parser and consider more cases invalid rather than silently ignored, but that would be a follow-up.

```
Jun 27 17:32:44 teg-x270 systemd[1]: Reloading D-Bus System Message Bus.
Jun 27 17:32:44 teg-x270 dbus-broker-launch[763]: Invalid XML in /usr/share/dbus-1/system.conf +141: mismatched tag
Jun 27 17:32:44 teg-x270 busctl[1729]: Config invalid. Reload ignored.
Jun 27 17:32:44 teg-x270 systemd[1]: dbus-broker.service: Control process exited, code=exited status=1
Jun 27 17:33:57 teg-x270 dbus-broker-launch[763]: Caught SIGHUP
Jun 27 17:33:57 teg-x270 dbus-broker-launch[763]: Invalid XML in /usr/share/dbus-1/system.conf +141: mismatched tag
Jun 27 17:33:57 teg-x270 dbus-broker-launch[763]: Invalid configuration. SIGHUP ignored.
```