### PR TITLE
Better handle invalid usernames in the config parser

### DIFF
--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -281,10 +281,10 @@ static int config_parser_attrs_policy(ConfigState *state, ConfigNode *node, cons
                         if (r) {
                                 if (r == NSS_CACHE_E_INVALID_NAME) {
                                         CONFIG_ERR(state, "Invalid user-name", ": %s=\"%s\"", k, v);
-                                        continue;
+                                        node->policy.id = (uint32_t)-1;
+                                } else {
+                                        return error_fold(r);
                                 }
-
-                                return error_fold(r);
                         }
 
                         node->policy.context = CONFIG_POLICY_USER;
@@ -296,10 +296,10 @@ static int config_parser_attrs_policy(ConfigState *state, ConfigNode *node, cons
                         if (r) {
                                 if (r == NSS_CACHE_E_INVALID_NAME) {
                                         CONFIG_ERR(state, "Invalid group-name", ": %s=\"%s\"", k, v);
-                                        continue;
+                                        node->policy.id = (uint32_t)-1;
+                                } else {
+                                        return error_fold(r);
                                 }
-
-                                return error_fold(r);
                         }
 
                         node->policy.context = CONFIG_POLICY_GROUP;
@@ -529,7 +529,7 @@ static int config_parser_attrs_allow_deny(ConfigState *state, ConfigNode *node, 
 
                 } else if (!strcmp(k, "user")) {
                         if (!strcmp(v, "*")) {
-                                node->allow_deny.uid = -1;
+                                node->allow_deny.uid = (uint32_t)-1;
                                 node->allow_deny.user = true;
                         } else {
                                 r = nss_cache_get_uid(state->nss, &node->allow_deny.uid, NULL, v);
@@ -546,7 +546,7 @@ static int config_parser_attrs_allow_deny(ConfigState *state, ConfigNode *node, 
                         }
                 } else if (!strcmp(k, "group")) {
                         if (!strcmp(v, "*")) {
-                                node->allow_deny.gid = -1;
+                                node->allow_deny.gid = (uint32_t)-1;
                                 node->allow_deny.group = true;
                         } else {
                                 r = nss_cache_get_gid(state->nss, &node->allow_deny.gid, v);

--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -386,11 +386,13 @@ static int policy_import_own(Policy *policy, ConfigNode *cnode) {
         }
 
         if (cnode->parent->policy.context == CONFIG_POLICY_USER) {
-                r = policy_at_uid(policy, &node, cnode->parent->policy.id);
-                if (r)
-                        return error_trace(r);
+                if (cnode->parent->policy.id != (uint32_t)-1) {
+                        r = policy_at_uid(policy, &node, cnode->parent->policy.id);
+                        if (r)
+                                return error_trace(r);
 
-                c_list_link_tail(&node->entries.own_list, &record->link);
+                        c_list_link_tail(&node->entries.own_list, &record->link);
+                }
         } else if (cnode->parent->policy.context == CONFIG_POLICY_NO_CONSOLE) {
                 c_list_link_tail(&policy->no_console_entries.own_list, &record->link);
         } else if (cnode->parent->policy.context == CONFIG_POLICY_AT_CONSOLE) {
@@ -474,21 +476,25 @@ static int policy_import_send(Policy *policy, ConfigNode *cnode) {
         policy_record_xmit_trim(record);
 
         if (cnode->parent->policy.context == CONFIG_POLICY_USER) {
-                r = policy_at_uid(policy, &node, cnode->parent->policy.id);
-                if (r)
-                        return error_trace(r);
+                if (cnode->parent->policy.id != (uint32_t)-1) {
+                        r = policy_at_uid(policy, &node, cnode->parent->policy.id);
+                        if (r)
+                                return error_trace(r);
 
-                c_list_link_tail(&node->entries.send_list, &record->link);
+                        c_list_link_tail(&node->entries.send_list, &record->link);
+                }
         } else if (cnode->parent->policy.context == CONFIG_POLICY_NO_CONSOLE) {
                 c_list_link_tail(&policy->no_console_entries.send_list, &record->link);
         } else if (cnode->parent->policy.context == CONFIG_POLICY_AT_CONSOLE) {
                 c_list_link_tail(&policy->at_console_entries.send_list, &record->link);
         } else if (cnode->parent->policy.context == CONFIG_POLICY_GROUP) {
-                r = policy_at_gid(policy, &node, cnode->parent->policy.id);
-                if (r)
-                        return error_trace(r);
+                if (cnode->parent->policy.id != (uint32_t)-1) {
+                        r = policy_at_gid(policy, &node, cnode->parent->policy.id);
+                        if (r)
+                                return error_trace(r);
 
-                c_list_link_tail(&node->entries.send_list, &record->link);
+                        c_list_link_tail(&node->entries.send_list, &record->link);
+                }
         } else {
                 c_list_link_tail(&policy->default_entries.send_list, &record->link);
         }
@@ -562,21 +568,25 @@ static int policy_import_recv(Policy *policy, ConfigNode *cnode) {
         policy_record_xmit_trim(record);
 
         if (cnode->parent->policy.context == CONFIG_POLICY_USER) {
-                r = policy_at_uid(policy, &node, cnode->parent->policy.id);
-                if (r)
-                        return error_trace(r);
+                if (cnode->parent->policy.id != (uint32_t)-1) {
+                        r = policy_at_uid(policy, &node, cnode->parent->policy.id);
+                        if (r)
+                                return error_trace(r);
 
-                c_list_link_tail(&node->entries.recv_list, &record->link);
+                        c_list_link_tail(&node->entries.recv_list, &record->link);
+                }
         } else if (cnode->parent->policy.context == CONFIG_POLICY_NO_CONSOLE) {
                 c_list_link_tail(&policy->no_console_entries.recv_list, &record->link);
         } else if (cnode->parent->policy.context == CONFIG_POLICY_AT_CONSOLE) {
                 c_list_link_tail(&policy->at_console_entries.recv_list, &record->link);
         } else if (cnode->parent->policy.context == CONFIG_POLICY_GROUP) {
-                r = policy_at_gid(policy, &node, cnode->parent->policy.id);
-                if (r)
-                        return error_trace(r);
+                if (cnode->parent->policy.id != (uint32_t)-1) {
+                        r = policy_at_gid(policy, &node, cnode->parent->policy.id);
+                        if (r)
+                                return error_trace(r);
 
-                c_list_link_tail(&node->entries.recv_list, &record->link);
+                        c_list_link_tail(&node->entries.recv_list, &record->link);
+                }
         } else {
                 c_list_link_tail(&policy->default_entries.recv_list, &record->link);
         }


### PR DESCRIPTION
It turns out to be more common than we'd like to have usernames in dbus config that are not defined on the system. Improve the logging and caching of these invalid entries.