### PR TITLE
broker: use parent seclabel for the driver

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -84,7 +84,7 @@ int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int control
         if (r)
                 return error_fold(r);
 
-        r = proc_get_seclabel(&broker->bus.seclabel, &broker->bus.n_seclabel);
+        r = proc_get_seclabel(PROC_SELF, &broker->bus.seclabel, &broker->bus.n_seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/util/proc.c
+++ b/src/util/proc.c
@@ -5,18 +5,22 @@
 #include <c-macro.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "util/error.h"
 #include "util/proc.h"
 
-/*
- * XXX: The kernel should be made to handle SO_PEERSEC also on
- *      socketpair sockets, making this redundant.
- */
-int proc_get_seclabel(char **labelp, size_t *n_labelp) {
+int proc_get_seclabel(pid_t pid, char **labelp, size_t *n_labelp) {
         _c_cleanup_(c_fclosep) FILE *f = NULL;
-        char buffer[LINE_MAX] = {}, *c, *label;
+        char path[64], buffer[LINE_MAX] = {}, *c, *label;
 
-        f = fopen("/proc/self/attr/current", "re");
+        if (pid == PROC_SELF)
+                strcpy(path, "/proc/self/attr/current");
+        else if (pid > 0)
+                sprintf(path, "/proc/%"PRIu32"/attr/current", (uint32_t)pid);
+        else
+                return error_origin(-EINVAL);
+
+        f = fopen(path, "re");
         if (f) {
                 errno = 0;
                 if (!fgets(buffer, sizeof(buffer), f)) {

--- a/src/util/proc.h
+++ b/src/util/proc.h
@@ -6,5 +6,8 @@
 
 #include <c-macro.h>
 #include <stdlib.h>
+#include <unistd.h>
 
-int proc_get_seclabel(char **labelp, size_t *n_labelp);
+#define PROC_SELF ((pid_t)0)
+
+int proc_get_seclabel(pid_t pid, char **labelp, size_t *n_labelp);

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -1525,7 +1525,7 @@ static void test_verify_selinux_context(sd_bus_message *reply) {
         size_t n_own_context;
         int r;
 
-        r = proc_get_seclabel(&own_context, &n_own_context);
+        r = proc_get_seclabel(PROC_SELF, &own_context, &n_own_context);
         assert(r >= 0);
 
         r = sd_bus_message_enter_container(reply, 'a', "y");


### PR DESCRIPTION
This makes the broker use the parent seclabel for the driver, as discussed offchannel. The reasoning is in the commit-message / inline-comment.