### PR TITLE
audit fixes

### DIFF
--- a/src/util/audit-fallback.c
+++ b/src/util/audit-fallback.c
@@ -24,7 +24,7 @@ int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
 int util_audit_log(const char *message, uid_t uid) {
         int r;
 
-        r = fputs(message, stderr);
+        r = fprintf(stderr, "%s\n", message);
         if (r < 0)
                 return error_origin(r);
 

--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -90,7 +90,7 @@ int util_audit_log(const char *message, uid_t uid) {
                 if (r <= 0)
                         return error_origin(-errno);
         } else {
-                r = fputs(message, stderr);
+                r = fprintf(stderr, "%s\n", message);
                 if (r < 0)
                         return error_origin(r);
         }

--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -123,6 +123,16 @@ int util_audit_init_global(void) {
 
         assert(audit_fd < 0);
 
+        r = capng_have_capability(CAPNG_EFFECTIVE, CAP_AUDIT_WRITE);
+        if (r == 0)
+                /*
+                 * Without the right capability, any writes will fail, so treat this
+                 * as if audit is unsupported.
+                 */
+                return 0;
+        else if (r == CAPNG_FAIL)
+                return error_origin(-EIO);
+
         r = audit_open();
         if (r < 0 && errno != EINVAL && errno != EPROTONOSUPPORT && errno != EAFNOSUPPORT)
                 return error_origin(-errno);


### PR DESCRIPTION
This makes the audit code more robust and fixes a bug. Firstly, gracefully handle the case when we are started without CAP_AUDIT_WRITE, and consider this the same as not having audit support (fallback to stderr). Secondly, make sure the broker correctly inherits CAP_AUDIT_WRITE from its parent, when possible and enabled.

Also make the error-handling a bit more robust after reviewing libcap-ng (whose documentation leaves much to be desired).