### PR TITLE
launcher: use c-init rather than g_key_file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "subprojects/c-shquote"]
 	path = subprojects/c-shquote
 	url = https://github.com/c-util/c-shquote.git
+[submodule "subprojects/c-ini"]
+	path = subprojects/c-ini
+	url = https://github.com/c-util/c-ini.git

--- a/README
+++ b/README
@@ -40,7 +40,6 @@ REQUIREMENTS:
         Additionally, the compatibility launcher requires:
 
             dbus >= 1.10
-            glib >= 2.50
             systemd >= 230
             expat >= 2.2
 

--- a/meson.build
+++ b/meson.build
@@ -25,12 +25,14 @@ mod_pkgconfig = import('pkgconfig')
 #
 
 sub_cdvar = subproject('c-dvar', version: '>=1')
+sub_cini = subproject('c-ini', version: '>=1')
 sub_clist = subproject('c-list', version: '>=3')
 sub_crbtree = subproject('c-rbtree', version: '>=3')
 sub_cshquote = subproject('c-shquote', version: '>=1')
 sub_csundry = subproject('c-sundry', version: '>=1')
 
 dep_cdvar = sub_cdvar.get_variable('libcdvar_dep')
+dep_cini = sub_cini.get_variable('libcini_dep')
 dep_clist = sub_clist.get_variable('libclist_dep')
 dep_crbtree = sub_crbtree.get_variable('libcrbtree_dep')
 dep_cshquote = sub_cshquote.get_variable('libcshquote_dep')
@@ -65,7 +67,6 @@ use_launcher = get_option('launcher')
 if use_launcher
         dep_dbus = dependency('dbus-1', version: '>=1.10')
         dep_expat = dependency('expat', version: '>=2.2')
-        dep_glib = dependency('glib-2.0', version: '>=2.50')
         dep_libsystemd = dependency('libsystemd', version: '>=230')
         dep_systemd = dependency('systemd', version: '>=230')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -139,10 +139,10 @@ if use_launcher
                 ],
                 dependencies: [
                         dep_bus,
+                        dep_cini,
                         dep_crbtree,
                         dep_cshquote,
                         dep_csundry,
-                        dep_glib,
                         dep_libsystemd,
                 ],
                 install: true,


### PR DESCRIPTION
c-ini is a stand-alone library, compatible with glib's g_key_file. Use
it to parse the DBus service files, dropping the glib dependency.