### PR TITLE
units/system: run in namespaces

### DIFF
--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -11,6 +11,10 @@ Type=notify
 Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
+ProtectSystem=full
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
 ExecStart=@bindir@/dbus-broker-launch --scope system --audit
 ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
 


### PR DESCRIPTION
This is mostly for the sake of documentation and catching bugs early.
dbus-broker does not need write-access to any filesystem nor does it
need access to devices or the network stack.

Signed-off-by: Tom Gundersen <teg@jklm.no>