### PR TITLE
connection: expose SASL issues

### DIFF
--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -46,6 +46,8 @@ static int peer_dispatch_connection(Peer *peer, uint32_t events) {
                                 return PEER_E_EOF;
                         else if (r == CONNECTION_E_QUOTA)
                                 return PEER_E_QUOTA;
+                        else if (r == CONNECTION_E_PROTOCOL_VIOLATION)
+                                return CONNECTION_E_PROTOCOL_VIOLATION;
 
                         return error_fold(r);
                 }

--- a/src/dbus/connection.h
+++ b/src/dbus/connection.h
@@ -18,6 +18,9 @@ typedef struct User User;
 enum {
         _CONNECTION_E_SUCCESS,
 
+        CONNECTION_E_SASL_FAILURE,
+        CONNECTION_E_PROTOCOL_VIOLATION,
+
         CONNECTION_E_EOF,
         CONNECTION_E_QUOTA,
 };


### PR DESCRIPTION
Rather than silently disconnecting, report either SASL failures or
protocol violations to the caller so they can decide what to do.

In the caller, log and disconnect.

Signed-off-by: Tom Gundersen <teg@jklm.no>