### PR TITLE
Treat unreadable service files as invalid

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -897,7 +897,7 @@ static int manager_ini_reader_parse_file(CIniGroup **groupp, const char *path) {
                         fprintf(stderr, "Unable to open service file '%s' (%d): %m\n", path, errno);
 
                 *groupp = NULL;
-                return 0;
+                return MANAGER_E_INVALID_SERVICE_FILE;
         }
 
         r = c_ini_reader_new(&reader);


### PR DESCRIPTION
This is a followup to a0869bdb8bb6dde92374bc12f5428913d5357653.
If we return 0 the parsing is considered complete and bad thing happen in manager_load_service_file