### PR TITLE
util/misc: fix saturating multipliers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -182,6 +182,9 @@ test('D-Bus Match Handling', test_match)
 test_message = executable('test-message', ['dbus/test-message.c'], dependencies: dep_bus)
 test('D-Bus Message Abstraction', test_message)
 
+test_misc = executable('test-misc', ['util/test-misc.c'], dependencies: dep_bus)
+test('Miscellaneous Helpers', test_misc)
+
 test_name = executable('test-name', ['bus/test-name.c'], dependencies: dep_bus)
 test('Name Registry', test_name)
 

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -11,13 +11,20 @@
 #include "util/error.h"
 #include "util/misc.h"
 
-
+/**
+ * util_umul64_saturating() - saturating multiplication
+ * @a:                  first operand
+ * @b:                  second operand
+ *
+ * This calculates @a multiplied by @b and returns the result. In case of an
+ * integer overflow, it will return `UINT64_MAX`.
+ *
+ * Return: The saturated result is returned.
+ */
 uint64_t util_umul64_saturating(uint64_t a, uint64_t b) {
-        unsigned long long res;
+        uint64_t res;
 
-        static_assert(sizeof(uint64_t) <= sizeof(res), "unsigned long long is smaller than 64 bits");
-
-        if (!__builtin_umulll_overflow(a, b, &res) || res > UINT64_MAX)
+        if (__builtin_mul_overflow(a, b, &res))
                 res = UINT64_MAX;
 
         return res;

--- a/src/util/test-misc.c
+++ b/src/util/test-misc.c
@@ -1,0 +1,40 @@
+/*
+ * Test miscellaneous helpers
+ */
+
+#include <c-macro.h>
+#include <stdlib.h>
+#include "util/misc.h"
+
+static void test_umul_saturating(void) {
+        static const struct {
+                uint64_t input_a;
+                uint64_t input_b;
+                uint64_t output;
+        } values[] = {
+                { 0, 0, 0 },
+                { 0, 1, 0 },
+                { 1, 0, 0 },
+                { 1, 1, 1 },
+
+                { UINT32_MAX, UINT32_MAX, UINT64_MAX - UINT64_C(2) * UINT32_MAX },
+                { UINT32_MAX, UINT32_MAX + UINT64_C(1), UINT64_MAX - UINT32_MAX },
+                { UINT32_MAX + UINT64_C(1), UINT32_MAX + UINT64_C(1), UINT64_MAX },
+
+                { 1, UINT64_MAX - 1, UINT64_MAX - 1 },
+                { UINT64_MAX - 1, 1, UINT64_MAX - 1 },
+                { UINT64_MAX - 1, 2, UINT64_MAX },
+        };
+        uint64_t output;
+        size_t i;
+
+        for (i = 0; i < C_ARRAY_SIZE(values); ++i) {
+                output = util_umul64_saturating(values[i].input_a, values[i].input_b);
+                assert(output == values[i].output);
+        }
+}
+
+int main(int argc, char **argv) {
+        test_umul_saturating();
+        return 0;
+}


### PR DESCRIPTION
Fix the `umul64_saturating` helper. See commit+commitmsg for details.