### PR TITLE
launch/service: fix state tracking

### DIFF
--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -503,7 +503,7 @@ int service_activate(Service *service) {
                 return 0;
         }
 
-        c_assert(service->state == SERVICE_STATE_CURRENT);
+        c_assert(service->running);
 
         if (service->unit) {
                 r = service_start_unit(service);
@@ -523,7 +523,7 @@ int service_add(Service *service) {
         _c_cleanup_(c_freep) char *object_path = NULL;
         int r;
 
-        if (service->state != SERVICE_STATE_PENDING)
+        if (service->running)
                 return 0;
 
         r = asprintf(&object_path, "/org/bus1/DBus/Name/%s", service->id);
@@ -544,8 +544,7 @@ int service_add(Service *service) {
         if (r < 0)
                 return error_origin(r);
 
-        service->state = SERVICE_STATE_CURRENT;
-
+        service->running = true;
         return 0;
 }
 
@@ -554,7 +553,7 @@ int service_remove(Service *service) {
         _c_cleanup_(c_freep) char *object_path = NULL;
         int r;
 
-        if (service->state == SERVICE_STATE_PENDING)
+        if (!service->running)
                 return 0;
 
         r = asprintf(&object_path, "/org/bus1/DBus/Name/%s", service->id);
@@ -572,7 +571,6 @@ int service_remove(Service *service) {
         if (r < 0)
                 return error_origin(r);
 
-        service->state = SERVICE_STATE_PENDING;
-
+        service->running = false;
         return 0;
 }

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -12,16 +12,11 @@
 
 typedef struct Service Service;
 
-typedef enum {
-        SERVICE_STATE_PENDING,
-        SERVICE_STATE_CURRENT,
-        SERVICE_STATE_DEFUNCT,
-} ServiceState;
-
 struct Service {
         Launcher *launcher;
-        ServiceState state;
         bool not_found;
+        bool running;
+        bool reload_tag;
         sd_bus_slot *slot;
         CRBNode rb;
         CRBNode rb_by_name;


### PR DESCRIPTION
The 'state' field is currently used for 2 purposes: To track whether a
service was pushed into the broker, and to track whether a service was
found during reload. While both can be tracked in the same state, it
makes things overly complex and the current solution is definitely
wrong. We do not consider failing configuration-reloads, which happen
to leave the reload-tag untouched. In those cases, we trigger the wrong
assertion in the activation path.

This patch splits the state into separate booleans. One to track
whether or not a services was pushed into the broker ('running'),
and one as throw-away tag for reload tracking ('reload_tag'). Note that
the value of the reload-tag is only correct *DURING RELOADS*. It is
garbage at all other times. Do not verify it. It is solely meant to be
used by the launcher to track services across reloads!