### PR TITLE
Fix running dbus-broker with <selinux> in the policy

### DIFF
--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -1138,7 +1138,7 @@ int policy_export(Policy *policy, sd_bus_message *m, uint32_t *at_console_uids, 
                 r = sd_bus_message_append(m, "(ss)",
                                           i_record->selinux.name,
                                           i_record->selinux.context);
-                if (r)
+                if (r < 0)
                         return error_origin(r);
         }
 

--- a/src/launch/policy.c
+++ b/src/launch/policy.c
@@ -613,8 +613,6 @@ static int policy_import_selinux(Policy *policy, ConfigNode *cnode) {
         if (r)
                 return error_trace(r);
 
-        policy_import_verdict(policy, record, cnode);
-
         record->selinux.name = cnode->associate.own;
         record->selinux.context = cnode->associate.context;
 


### PR DESCRIPTION
dbus-broker crashes on startup if the policy includes ```<selinux>``` elements. I have verified on a yocto-based distro that with the following fixes everything works. A process with the correct label is allowed to own an interface, and a process without the correct label is not.

Fixes #212 