### PR TITLE
launch/service: support noop activation files

### DIFF
--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -614,17 +614,6 @@ static int launcher_load_service_file(Launcher *launcher, const char *path, cons
                 return LAUNCHER_E_INVALID_SERVICE_FILE;
         }
 
-        if (!unit_entry && !exec_entry) {
-                log_append_here(&launcher->log, LOG_ERR, 0, DBUS_BROKER_CATALOG_SERVICE_INVALID);
-                log_append_service_path(&launcher->log, path);
-
-                r = log_commitf(&launcher->log, "Missing exec or unit in service file '%s'\n", path);
-                if (r)
-                        return error_fold(r);
-
-                return LAUNCHER_E_INVALID_SERVICE_FILE;
-        }
-
         name = c_ini_entry_get_value(name_entry, &n_name);
         if (!dbus_validate_name(name, n_name)) {
                 log_append_here(&launcher->log, LOG_ERR, 0, DBUS_BROKER_CATALOG_SERVICE_INVALID);

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -499,7 +499,12 @@ int service_activate(Service *service) {
         int r;
 
         if (!strcmp(service->name, "org.freedesktop.systemd1")) {
-                /* pid1 activation requests are silently ignored */
+                /*
+                 * systemd activation requests are silently ignored.
+                 * In the future this special-case can be dropped
+                 * once systemd ships a service file without an
+                 * Exec directive.
+                 */
                 return 0;
         }
 
@@ -509,7 +514,7 @@ int service_activate(Service *service) {
                 r = service_start_unit(service);
                 if (r)
                         return error_trace(r);
-        } else {
+        } else if (service->argc > 0) {
                 r = service_start_transient_unit(service);
                 if (r)
                         return error_trace(r);

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -863,6 +863,20 @@ static void test_start_service_by_name(void) {
                 c_assert(!strcmp(error.name, "org.freedesktop.DBus.Error.ServiceUnknown"));
         }
 
+        /* start pid1 name */
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+                _c_cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+
+                util_broker_connect(broker, &bus);
+
+                r = sd_bus_call_method(bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "StartServiceByName", &error, NULL,
+                                       "su", "org.freedesktop.systemd1", 0);
+                c_assert(r < 0);
+                c_assert(!strcmp(error.name, "org.freedesktop.DBus.Error.ServiceUnknown"));
+        }
+
         /* start invalid name */
         {
                 _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;


### PR DESCRIPTION
If SystemdService and Exec are both missing from the service files
then we still treat the name as activatable, but no explicit action
is needed from us in order to start it (it is going to be started
by the system, and activation is only used to avoid a race).

See discussion here: https://github.com/systemd/systemd/pull/14405