### PR TITLE
Implement org.freedesktop.DBus.Debug.Stats.GetStats()

### DIFF
--- a/src/bus/activation.c
+++ b/src/bus/activation.c
@@ -84,6 +84,32 @@ void activation_deinit(Activation *activation) {
         }
 }
 
+/**
+ * activation_get_stats_for() - XXX
+ */
+void activation_get_stats_for(Activation *activation,
+                              uint64_t owner_id,
+                              unsigned int *n_bytesp,
+                              unsigned int *n_fdsp) {
+        ActivationRequest *request;
+        ActivationMessage *message;
+        unsigned int n_bytes = 0, n_fds = 0;
+
+        c_list_for_each_entry(message, &activation->activation_messages, link) {
+                if (owner_id == message->message->metadata.sender_id) {
+                        n_bytes += message->charges[0].charge;
+                        n_fds += message->charges[1].charge;
+                }
+        }
+
+        c_list_for_each_entry(request, &activation->activation_requests, link)
+                if (owner_id == request->sender_id)
+                        n_bytes += request->charge.charge;
+
+        *n_bytesp = n_bytes;
+        *n_fdsp = n_fds;
+}
+
 static int activation_request(Activation *activation) {
         int r;
 

--- a/src/bus/activation.h
+++ b/src/bus/activation.h
@@ -68,6 +68,10 @@ ActivationMessage *activation_message_free(ActivationMessage *message);
 int activation_init(Activation *activation, Name *name, User *user);
 void activation_deinit(Activation *activation);
 
+void activation_get_stats_for(Activation *activation,
+                              uint64_t owner_id,
+                              unsigned int *n_bytesp,
+                              unsigned int *n_fdsp);
 int activation_queue_message(Activation *activation,
                              User *user,
                              NameOwner *names,

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -200,6 +200,22 @@ static const CDVarType driver_type_out_apsv[] = {
                 )
         )
 };
+static const CDVarType driver_type_out_apsas[] = {
+        C_DVAR_T_INIT(
+                DRIVER_T_MESSAGE(
+                        C_DVAR_T_TUPLE1(
+                                C_DVAR_T_ARRAY(
+                                        C_DVAR_T_PAIR(
+                                                C_DVAR_T_s,
+                                                C_DVAR_T_ARRAY(
+                                                        C_DVAR_T_s
+                                                )
+                                        )
+                                )
+                        )
+                )
+        )
+};
 
 static void driver_write_bytes(CDVar *var, const char *bytes, size_t n_bytes) {
         c_dvar_write(var, "[");
@@ -1699,6 +1715,18 @@ static int driver_method_introspect(Peer *peer, const char *path, CDVar *in_v, u
                 "    <method name=\"Ping\">\n"
                 "    </method>\n"
                 "  </interface>\n"
+                "  <interface name=\"org.freedesktop.DBus.Debug.Stats\">\n"
+                "    <method name=\"GetStats\">\n"
+                "      <arg direction=\"out\" type=\"a{sv}\"/>\n"
+                "    </method>\n"
+                "    <method name=\"GetConnectionStats\">\n"
+                "      <arg direction=\"in\" type=\"s\"/>\n"
+                "      <arg direction=\"out\" type=\"a{sv}\"/>\n"
+                "    </method>\n"
+                "    <method name=\"GetAllMatchRules\">\n"
+                "      <arg direction=\"out\" type=\"a{sas}\"/>\n"
+                "    </method>\n"
+                "  </interface>\n"
                 "</node>\n";
         static const char *introspection_org_freedesktop =
                 "<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"\n"
@@ -1981,6 +2009,18 @@ static int driver_method_get_all(Peer *peer, const char *path, CDVar *in_v, uint
         return 0;
 }
 
+static int driver_method_get_stats(Peer *peer, const char *path, CDVar *in_v, uint32_t serial, CDVar *out_v) {
+        return DRIVER_E_PEER_NOT_PRIVILEGED;
+}
+
+static int driver_method_get_connection_stats(Peer *peer, const char *path, CDVar *in_v, uint32_t serial, CDVar *out_v) {
+        return DRIVER_E_PEER_NOT_PRIVILEGED;
+}
+
+static int driver_method_get_all_match_rules(Peer *peer, const char *path, CDVar *in_v, uint32_t serial, CDVar *out_v) {
+        return DRIVER_E_PEER_NOT_PRIVILEGED;
+}
+
 static int driver_handle_method(const DriverMethod *method, Peer *peer, const char *path, uint32_t serial, const char *signature_in, Message *message_in) {
         _c_cleanup_(c_dvar_deinit) CDVar var_in = C_DVAR_INIT, var_out = C_DVAR_INIT;
         int r;
@@ -2065,6 +2105,13 @@ static const DriverMethod properties_methods[] = {
         { },
 };
 
+static const DriverMethod debug_stats_methods[] = {
+        { "GetStats",                                   true,   "/org/freedesktop/DBus",        driver_method_get_stats,                                        c_dvar_type_unit,       driver_type_out_apsv },
+        { "GetConnectionStats",                         true,   "/org/freedesktop/DBus",        driver_method_get_connection_stats,                             driver_type_in_s,       driver_type_out_apsv },
+        { "GetAllMatchRules",                           true,   "/org/freedesktop/DBus",        driver_method_get_all_match_rules,                              c_dvar_type_unit,       driver_type_out_apsas },
+        { },
+};
+
 static int driver_dispatch_method(Peer *peer, const DriverMethod *methods, uint32_t serial, const char *method, const char *path, const char *signature, Message *message) {
         for (size_t i = 0; methods[i].name; i++) {
                 if (strcmp(methods[i].name, method) != 0)
@@ -2084,6 +2131,7 @@ static int driver_dispatch_interface(Peer *peer, uint32_t serial, const char *in
                 { "org.freedesktop.DBus.Introspectable", introspectable_methods },
                 { "org.freedesktop.DBus.Peer", peer_methods },
                 { "org.freedesktop.DBus.Properties", properties_methods },
+                { "org.freedesktop.DBus.Debug.Stats", debug_stats_methods },
         };
         int r;
 

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1686,7 +1686,7 @@ static int driver_method_introspect(Peer *peer, const char *path, CDVar *in_v, u
                 "    <method name=\"GetMachineId\">\n"
                 "      <arg direction=\"out\" type=\"s\"/>\n"
                 "    </method>\n"
-                "      <method name=\"Ping\">\n"
+                "    <method name=\"Ping\">\n"
                 "    </method>\n"
                 "  </interface>\n"
                 "</node>\n";

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -922,6 +922,22 @@ void match_owner_deinit(MatchOwner *owner) {
 }
 
 /**
+ * match_owner_get_stats() - XXX
+ */
+void match_owner_get_stats(MatchOwner *owner, unsigned int *n_bytesp, unsigned int *n_matchesp) {
+        MatchRule *rule;
+        unsigned int n_bytes = 0, n_matches = 0;
+
+        c_rbtree_for_each_entry(rule, &owner->rule_tree, owner_node) {
+                n_bytes += rule->charge[0].charge;
+                n_matches += rule->charge[1].charge;
+        }
+
+        *n_bytesp = n_bytes;
+        *n_matchesp = n_matches;
+}
+
+/**
  * match_owner_move() - XXX
  */
 void match_owner_move(MatchOwner *to, MatchOwner *from) {

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -176,6 +176,7 @@ C_DEFINE_CLEANUP(MatchRule *, match_rule_user_unref);
 void match_owner_init(MatchOwner *owner);
 void match_owner_deinit(MatchOwner *owner);
 
+void match_owner_get_stats(MatchOwner *owner, unsigned int *n_bytesp, unsigned int *n_matchesp);
 void match_owner_move(MatchOwner *to, MatchOwner *from);
 int match_owner_ref_rule(MatchOwner *owner, MatchRule **rulep, User *user, const char *rule_string);
 int match_owner_find_rule(MatchOwner *owner, MatchRule **rulep, const char *rule_string);

--- a/src/bus/name.h
+++ b/src/bus/name.h
@@ -141,11 +141,17 @@ void name_free(_Atomic unsigned long *n_refs, void *userdata);
 void name_owner_init(NameOwner *owner);
 void name_owner_deinit(NameOwner *owner);
 
+void name_owner_get_stats(NameOwner *owner, unsigned int *n_objectsp);
+
 /* registry */
 
 void name_registry_init(NameRegistry *registry);
 void name_registry_deinit(NameRegistry *registry);
 
+void name_registry_get_activation_stats_for(NameRegistry *registry,
+                                            uint64_t owner_id,
+                                            unsigned int *n_bytesp,
+                                            unsigned int *n_fdsp);
 int name_registry_ref_name(NameRegistry *registry, Name **namep, const char *name_str);
 Name *name_registry_find_name(NameRegistry *registry, const char *name_str);
 

--- a/src/bus/reply.c
+++ b/src/bus/reply.c
@@ -108,3 +108,11 @@ void reply_owner_init(ReplyOwner *owner) {
 void reply_owner_deinit(ReplyOwner *owner) {
         c_assert(c_list_is_empty(&owner->reply_list));
 }
+
+void reply_owner_get_stats(ReplyOwner *owner, unsigned int *n_objectsp) {
+        ReplySlot *reply;
+        unsigned int n_objects = 0;
+
+        c_list_for_each_entry(reply, &owner->reply_list, owner_link)
+                n_objects += reply->charge.charge;
+}

--- a/src/bus/reply.h
+++ b/src/bus/reply.h
@@ -58,4 +58,6 @@ void reply_registry_deinit(ReplyRegistry *registry);
 void reply_owner_init(ReplyOwner *owner);
 void reply_owner_deinit(ReplyOwner *owner);
 
+void reply_owner_get_stats(ReplyOwner *owner, unsigned int *n_objectsp);
+
 C_DEFINE_CLEANUP(ReplySlot *, reply_slot_free);

--- a/src/dbus/connection.c
+++ b/src/dbus/connection.c
@@ -94,6 +94,17 @@ void connection_deinit(Connection *connection) {
         socket_deinit(&connection->socket);
 }
 
+/**
+ * connection_get_stats() - XXX
+ */
+void connection_get_stats(Connection *connection,
+                          unsigned int *n_in_bytesp,
+                          unsigned int *n_in_fdsp,
+                          unsigned int *n_out_bytesp,
+                          unsigned int *n_out_fdsp) {
+        socket_get_stats(&connection->socket, n_in_bytesp, n_in_fdsp, n_out_bytesp, n_out_fdsp);
+}
+
 static int connection_feed_sasl(Connection *connection, const char *input, size_t n_input) {
         const char *output;
         size_t n_output;

--- a/src/dbus/connection.h
+++ b/src/dbus/connection.h
@@ -56,6 +56,11 @@ int connection_init_client(Connection *connection,
                            int fd);
 void connection_deinit(Connection *connection);
 
+void connection_get_stats(Connection *connection,
+                          unsigned int *n_in_bytesp,
+                          unsigned int *n_in_fdsp,
+                          unsigned int *n_out_bytesp,
+                          unsigned int *n_out_fdsp);
 int connection_open(Connection *connection);
 void connection_shutdown(Connection *connection);
 void connection_close(Connection *connection);

--- a/src/dbus/socket.h
+++ b/src/dbus/socket.h
@@ -74,6 +74,11 @@ int socket_queue(Socket *socket, User *user, Message *message);
 int socket_dispatch(Socket *socket, uint32_t event);
 void socket_shutdown(Socket *socket);
 void socket_close(Socket *socket);
+void socket_get_stats(Socket *socket,
+                      unsigned int *n_in_bytesp,
+                      unsigned int *n_in_fdsp,
+                      unsigned int *n_out_bytesp,
+                      unsigned int *n_out_fdsp);
 
 C_DEFINE_CLEANUP(Socket *, socket_deinit);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,9 @@ endif
 #
 
 sources_bus = [
+        'broker/broker.c',
+        'broker/controller.c',
+        'broker/controller-dbus.c',
         'bus/activation.c',
         'bus/bus.c',
         'bus/driver.c',
@@ -115,9 +118,6 @@ dep_bus = declare_dependency(
 exe_dbus_broker = executable(
         'dbus-broker',
         [
-                'broker/broker.c',
-                'broker/controller.c',
-                'broker/controller-dbus.c',
                 'broker/main.c',
         ],
         dependencies: [

--- a/src/util/user.c
+++ b/src/util/user.c
@@ -30,17 +30,6 @@
 #include "util/ref.h"
 #include "util/user.h"
 
-struct UserUsage {
-        _Atomic unsigned long n_refs;
-        User *user;
-        uid_t uid;
-        CRBNode user_node;
-
-        bool logged : 1;
-
-        unsigned int slots[];
-};
-
 static void user_usage_link(UserUsage *usage, CRBNode *parent, CRBNode **slot) {
         ++usage->user->n_usages;
         c_rbtree_add(&usage->user->usage_tree, parent, slot, &usage->user_node);

--- a/src/util/user.h
+++ b/src/util/user.h
@@ -47,6 +47,19 @@ enum {
         USER_E_QUOTA,
 };
 
+/* usage */
+
+struct UserUsage {
+        _Atomic unsigned long n_refs;
+        User *user;
+        uid_t uid;
+        CRBNode user_node;
+
+        bool logged : 1;
+
+        unsigned int slots[];
+};
+
 /* charge */
 
 struct UserCharge {


### PR DESCRIPTION
This implements the fdo.DBus.Debug.Stats interface, in particular it implements GetStats() which allows to query all the accounting information of a running dbus-broker instance.

This will hopefully allow us to further debug any accounting issues people report to us.