### PR TITLE
bus/driver: allow eavesdrop filters for monitors

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -1808,7 +1808,17 @@ static int driver_method_become_monitor(Peer *peer, const char *path, CDVar *in_
                 else
                         match_string = "";
 
-                r = match_owner_ref_rule(&owned_matches, NULL, peer->user, match_string);
+                /*
+                 * We pass `true` for `allow_eavesdrop` for compatibility
+                 * reasons. We do not support eavesdropping, but `dbus-monitor`
+                 * seems to prepend `eavesdrop=true` unconditionally to all
+                 * match-rules it installs. However, there is no reason to do
+                 * that with `BecomeMonitor()`, because this is already
+                 * implicitly set.
+                 * Regardless, we must allow these rules to specify `eavesdrop`
+                 * filters, even though we will just silently ignore them.
+                 */
+                r = match_owner_ref_rule(&owned_matches, NULL, peer->user, match_string, true);
                 if (r) {
                         r = (r == MATCH_E_INVALID) ? DRIVER_E_MATCH_INVALID : error_fold(r);
                         goto error;

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -178,7 +178,7 @@ void match_owner_deinit(MatchOwner *owner);
 
 void match_owner_get_stats(MatchOwner *owner, unsigned int *n_bytesp, unsigned int *n_matchesp);
 void match_owner_move(MatchOwner *to, MatchOwner *from);
-int match_owner_ref_rule(MatchOwner *owner, MatchRule **rulep, User *user, const char *rule_string);
+int match_owner_ref_rule(MatchOwner *owner, MatchRule **rulep, User *user, const char *rule_string, bool allow_eavesdrop);
 int match_owner_find_rule(MatchOwner *owner, MatchRule **rulep, const char *rule_string);
 
 /* registry */

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -591,7 +591,7 @@ int peer_add_match(Peer *peer, const char *rule_string) {
         _c_cleanup_(match_rule_user_unrefp) MatchRule *rule = NULL;
         int r;
 
-        r = match_owner_ref_rule(&peer->owned_matches, &rule, peer->user, rule_string);
+        r = match_owner_ref_rule(&peer->owned_matches, &rule, peer->user, rule_string, false);
         if (r) {
                 if (r == MATCH_E_QUOTA)
                         return PEER_E_QUOTA;


### PR DESCRIPTION
As it turns out `dbus-monitor` unconditionally prepends `eavesdrop=true`
to all filters it installs. This was necessary back in the days when it
actually used eavesdropping, but with BecomeMonitor() this is no longer
necessary. However, the code is still there and used in the wild.

To support `dbus-monitor` with custom matches, this commit makes
BecomeMonitor() treat the matches special and allows parsing `eavesdrop`
rules just like we used to:

        commit ce67e4e7091416d8cd7021b63babbfed7a01d7fd
        Author: Tom Gundersen <teg@jklm.no>
        Date:   Thu Aug 3 08:40:52 2017 +0200

            match: drop support for eavesdropping

We still silently ignore the flag, since it carries no meaning for
monitors, and in all other cases we do not allow it, anyway.