### PR TITLE
broker: force SO_PEERSEC if new option linux-4-17 is set

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,14 @@ if use_launcher
 endif
 
 #
+# Config: linux-4-17
+#
+
+require_linux_4_17 = get_option('linux-4-17')
+
+add_project_arguments('-DREQUIRE_LINUX_4_17=' + require_linux_4_17.to_int().to_string(), language: 'c')
+
+#
 # Config: reference-test
 #
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('audit', type: 'boolean', value: false, description: 'Audit support')
 option('docs', type: 'boolean', value: false, description: 'Build documentation')
 option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
+option('linux-4-17', type: 'boolean', value: false, description: 'Require linux-4.17 at runtime and make use of its features')
 option('reference-test', type: 'boolean', value: false, description: 'Run test suite against reference implementation')
 option('selinux', type: 'boolean', value: false, description: 'SELinux support')
 option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('audit', type: 'boolean', value: false, description: 'Audit support')
-option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
 option('docs', type: 'boolean', value: false, description: 'Build documentation')
+option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
 option('reference-test', type: 'boolean', value: false, description: 'Run test suite against reference implementation')
 option('selinux', type: 'boolean', value: false, description: 'SELinux support')
 option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -21,6 +21,7 @@
 #include "util/error.h"
 #include "util/log.h"
 #include "util/proc.h"
+#include "util/sockopt.h"
 #include "util/user.h"
 
 static int broker_dispatch_signals(DispatchFile *file) {
@@ -86,23 +87,27 @@ int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int control
                 return error_fold(r);
 
         /*
-         * XXX: We need the seclabel to run the broker for 2 reasons: First,
-         *      if 'org.freedesktop.DBus' is queried for the seclabel, we need
-         *      to return some value. Second, all unlabeled names get this
-         *      label assigned by default.
-         *      Due to the latter, this seclabel is actually referenced in
-         *      selinux rules, to allow peers to own names.
-         *      Preferably, we would call SO_PEERSEC on the controller socket.
-         *      However, this used to return the 'unlabeled_t' entry for
-         *      socketpairs until kernel v4.17. From v4.17 onwards it now
-         *      returns the correct label. Hence, once we have v4.17 as
-         *      hard-requirement, we should switch to SO_PEERSEC here. Until
-         *      then, we keep reading the seclabel of the parent-pid as
-         *      workaround.
+         * We need the seclabel to run the broker for 2 reasons: First, if
+         * 'org.freedesktop.DBus' is queried for the seclabel, we need to
+         * return some value. Second, all unlabeled names get this label
+         * assigned by default. Due to the latter, this seclabel is actually
+         * referenced in selinux rules, to allow peers to own names.
+         * Preferably, we would call SO_PEERSEC on the controller socket.
+         * However, this used to return the 'unlabeled_t' entry for socketpairs
+         * until kernel v4.17. From v4.17 onwards it now returns the correct
+         * label. There is no way to detect this at runtime, though. Hence, we
+         * have to run the fallback as long as we do not have v4.17 as
+         * hard-requirement.
          */
-        r = proc_get_seclabel(getppid(), &broker->bus.seclabel, &broker->bus.n_seclabel);
-        if (r)
-                return error_fold(r);
+        if (REQUIRE_LINUX_4_17) {
+                r = sockopt_get_peersec(controller_fd, &broker->bus.seclabel, &broker->bus.n_seclabel);
+                if (r)
+                        return error_fold(r);
+        } else {
+                r = proc_get_seclabel(getppid(), &broker->bus.seclabel, &broker->bus.n_seclabel);
+                if (r)
+                        return error_fold(r);
+        }
 
         broker->bus.pid = ucred.pid;
         r = user_registry_ref_user(&broker->bus.users, &broker->bus.user, ucred.uid);


### PR DESCRIPTION
This introduces a new meson-option called 'linux-4-17=false', which when set to `true` allows us to depend on linux v4.17 features. In particular, this allows us to enforce `SO_PEERSEC` to read our own credentials, rather than reading `/proc/<ppid>`.

The idea here is to have this as a smooth transition and allow people to use the new features in controlled environments. At some point, we will set the option to default to `true` and reject builds with this set to `false`. This way, we have a backwards compatible option and will not break build-setups that do not care for this.