### PR TITLE
broker/broker: use SO_PEERCRED.pid over getppid()

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -104,7 +104,7 @@ int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int control
                 if (r)
                         return error_fold(r);
         } else {
-                r = proc_get_seclabel(getppid(), &broker->bus.seclabel, &broker->bus.n_seclabel);
+                r = proc_get_seclabel(ucred.pid, &broker->bus.seclabel, &broker->bus.n_seclabel);
                 if (r)
                         return error_fold(r);
         }


### PR DESCRIPTION
When querying for LSM credentials of our parent, we want the strategy
forward to be using SO_PEERSEC. In the fallback-path, we use /proc on
the parent pid. To reduce the differences between those paths, actually
use the pid from the controller-socket over getppid(). This now reduces
the differences to just where we fetch the data from.