### PR TITLE
Implement UnixGroupIDs in GetConnectionCredentials()

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -109,6 +109,15 @@ int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int control
                         return error_fold(r);
         }
 
+        r = sockopt_get_peergroups(controller_fd,
+                                   &broker->log,
+                                   ucred.uid,
+                                   ucred.gid,
+                                   &broker->bus.gids,
+                                   &broker->bus.n_gids);
+        if (r)
+                return error_fold(r);
+
         broker->bus.pid = ucred.pid;
         r = user_registry_ref_user(&broker->bus.users, &broker->bus.user, ucred.uid);
         if (r)

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -52,6 +52,8 @@ int bus_init(Bus *bus,
 void bus_deinit(Bus *bus) {
         bus->n_seclabel = 0;
         bus->seclabel = c_free(bus->seclabel);
+        bus->n_gids = 0;
+        bus->gids = c_free(bus->gids);
         bus->pid = 0;
         bus->user = user_unref(bus->user);
         metrics_deinit(&bus->metrics);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -7,6 +7,7 @@
 #include <c-rbtree.h>
 #include <c-stdaux.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include "bus/listener.h"
 #include "bus/match.h"
 #include "bus/name.h"
@@ -34,6 +35,8 @@ struct Bus {
         Log *log;
         User *user;
         pid_t pid;
+        gid_t *gids;
+        size_t n_gids;
         char *seclabel;
         size_t n_seclabel;
         char machine_id[33];

--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -60,7 +60,8 @@ int sockopt_get_peersec(int fd, char **labelp, size_t *lenp) {
 
 int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t gid, gid_t **gidsp, size_t *n_gidsp) {
         _c_cleanup_(c_freep) gid_t *gids = NULL;
-        int r, n_gids = 64;
+        socklen_t socklen;
+        int r, n_gids;
         void *tmp;
 
         /*
@@ -80,7 +81,8 @@ int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t gid, gid_t **gidsp
          * You are highly recommended to run >=linux-4.13.
          */
         {
-                socklen_t socklen = n_gids * sizeof(*gids);
+                n_gids = 8;
+                socklen = n_gids * sizeof(*gids);
 
                 gids = malloc(sizeof(gid) + socklen);
                 if (!gids)
@@ -147,6 +149,7 @@ int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t gid, gid_t **gidsp
                 if (!passwd)
                         return error_origin(-errno);
 
+                n_gids = 8;
                 do {
                         n_gids_previous = n_gids;
                         tmp = realloc(gids, sizeof(*gids) * n_gids);

--- a/src/util/sockopt.h
+++ b/src/util/sockopt.h
@@ -10,4 +10,4 @@
 typedef struct Log Log;
 
 int sockopt_get_peersec(int fd, char **labelp, size_t *lenp);
-int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t gid, gid_t **gidsp, size_t *n_gidsp);
+int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t primary_gid, gid_t **gidsp, size_t *n_gidsp);

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -1652,7 +1652,7 @@ static void test_verify_selinux_context(sd_bus_message *reply) {
 }
 
 static void test_verify_credentials(sd_bus_message *message) {
-        bool got_uid = false, got_pid = false;
+        bool got_uid = false, got_pid = false, got_gids = false;
         int r;
 
         /* We do not fail on unexpected credentials. */
@@ -1676,6 +1676,8 @@ static void test_verify_credentials(sd_bus_message *message) {
                         got_uid = true;
                 else if (strcmp(key, "ProcessID") == 0)
                         got_pid = true;
+                else if (strcmp(key, "UnixGroupIDs") == 0)
+                        got_gids = true;
         }
 
         r = sd_bus_message_exit_container(message);
@@ -1683,6 +1685,7 @@ static void test_verify_credentials(sd_bus_message *message) {
 
         c_assert(got_uid);
         c_assert(got_pid);
+        c_assert(got_gids);
 
         /*
          * XXX: verify that we get the security label at least when SELinux is enabled


### PR DESCRIPTION
Since dbus-specification-0.53 the GetConnectionCredentials() call now returns the list of supplementary groups as `UnixGroupIDs`. This series implements this, including a handful of minor fixes.