### PR TITLE
launch/main: fix error propagation

### DIFF
--- a/src/launch/main.c
+++ b/src/launch/main.c
@@ -146,13 +146,10 @@ static int run(void) {
 
         r = launcher_new(&launcher, main_fd_listen, main_arg_audit, main_arg_configfile, main_arg_user_scope);
         if (r)
-                return error_trace(r);
+                return error_fold(r);
 
         r = launcher_run(launcher);
-        if (r)
-                r = error_trace(r);
-
-        return r;
+        return error_fold(r);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
We incorrectly forward launcher errors from the launcher namespace to
the main application namespace. This is wrong, these are separate
namespaces, so we have to fold the error.

This fixes an issue were we would treat LAUNCHER_E_INVALID_CONFIG as
MAIN_EXIT, and thus not return with an error code.

This should fix #216.