### PR TITLE
launcher: escape transient unit names

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -43,6 +43,7 @@ sources_bus = [
         'util/proc.c',
         'util/sockopt.c',
         'util/string.c',
+        'util/systemd.c',
         'util/user.c',
 ]
 
@@ -213,6 +214,9 @@ test('D-Bus Socket Abstraction', test_socket)
 
 test_stitching = executable('test-stitching', ['dbus/test-stitching.c'], dependencies: dep_bus)
 test('Message Sender Stitching', test_stitching)
+
+test_systemd = executable('test-systemd', ['util/test-systemd.c'], dependencies: dep_bus)
+test('Systemd Utilities', test_systemd)
 
 test_user = executable('test-user', ['util/test-user.c'], dependencies: dep_bus)
 test('User Accounting', test_user)

--- a/src/util/systemd.c
+++ b/src/util/systemd.c
@@ -1,0 +1,64 @@
+/*
+ * Systemd Utilities
+ */
+
+#include <c-stdaux.h>
+#include <stdlib.h>
+#include "util/error.h"
+#include "util/systemd.h"
+
+static bool needs_escape(char c) {
+        return !strchr("0123456789"
+                       "abcdefghijklmnopqrstuvwxyz"
+                       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                       ":_.", c);
+}
+
+static char *escape_char(char *t, char c) {
+        static const char table[16] = "0123456789abcdef";
+
+        *t++ = '\\';
+        *t++ = 'x';
+        *t++ = table[(c >> 4) & 0x0f];
+        *t++ = table[c & 0x0f];
+
+        return t;
+}
+
+/**
+ * systemd_escape_unit() - escape unit name
+ * @escapedp:           output argument for escaped unit name
+ * @unescaped:          unescaped unit name to operate with
+ *
+ * This escapes the specified systemd unit name and returns it in the specified
+ * output pointer.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int systemd_escape_unit(char **escapedp, const char *unescaped) {
+        char *buffer, *dst;
+        const char *src;
+
+        buffer = malloc(strlen(unescaped) * 4 + 1);
+        if (!buffer)
+                return error_origin(-ENOMEM);
+
+        src = unescaped;
+        dst = buffer;
+
+        if (*src == '.')
+                dst = escape_char(dst, *src++);
+
+        for ( ; *src; ++src) {
+                if (*src == '/')
+                        *dst++ = '-';
+                else if (needs_escape(*src))
+                        dst = escape_char(dst, *src);
+                else
+                        *dst++ = *src;
+        }
+
+        *dst = 0;
+        *escapedp = buffer;
+        return 0;
+}

--- a/src/util/systemd.h
+++ b/src/util/systemd.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/*
+ * Systemd Utilities
+ */
+
+#include <c-stdaux.h>
+#include <stdlib.h>
+
+int systemd_escape_unit(char **escapedp, const char *unescaped);

--- a/src/util/test-systemd.c
+++ b/src/util/test-systemd.c
@@ -1,0 +1,39 @@
+/*
+ * Test systemd helpers
+ */
+
+#undef NDEBUG
+#include <c-stdaux.h>
+#include <stdlib.h>
+#include "util/systemd.h"
+
+static void test_systemd_escape_unit(void) {
+        static const char * const from[] = {
+                "foobar",
+                "-foobar",
+                "/foo/bar/",
+                "\\foobar",
+                ".foo.bar",
+        };
+        static const char * const to[] = {
+                "foobar",
+                "\\x2dfoobar",
+                "-foo-bar-",
+                "\\x5cfoobar",
+                "\\x2efoo.bar",
+        };
+
+        for (size_t i = 0; i < C_ARRAY_SIZE(from); ++i) {
+                _c_cleanup_(c_freep) char *e = NULL;
+                int r;
+
+                r = systemd_escape_unit(&e, from[i]);
+                c_assert(!r);
+                c_assert(!strcmp(e, to[i]));
+        }
+}
+
+int main(int argc, char **argv) {
+        test_systemd_escape_unit();
+        return 0;
+}


### PR DESCRIPTION
This series imports a new helper similar to `systemd-escape(5)`, which allows us to escape systemd unit names. It then uses it to correctly escape the unit-name suffix for transient units.

This attempts to fix #230.