### PR TITLE
broker: fix some error-paths to be more verbose

### DIFF
--- a/src/broker/main.c
+++ b/src/broker/main.c
@@ -253,13 +253,17 @@ int main(int argc, char **argv) {
 
         if (main_arg_audit) {
                 r = util_audit_init_global();
-                if (r)
-                        return error_fold(r);
+                if (r) {
+                        r = error_fold(r);
+                        goto exit;
+                }
         }
 
         r = bus_selinux_init_global();
-        if (r)
-                return error_fold(r);
+        if (r) {
+                r = error_fold(r);
+                goto exit;
+        }
 
         r = run();
 

--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -1404,7 +1404,7 @@ int launcher_run(Launcher *launcher) {
         if (r < 0)
                 return error_origin(r);
         else if (r > 0)
-                return r;
+                return error_fold(r);
 
         return 0;
 }


### PR DESCRIPTION
A set of 3 error-path fixes. The first two fix `dbus-broker` from using
the default exit-path for audit/selinux initialization failures, and
thus properly printing debug messages.

The third fix changes `sd_event_loop()` to fold the return code. It uses
a separate error-domain, so we should always properly fold and
participaite in the error-trace.