### PR TITLE
launch/config: be more verbose about missing files

### DIFF
--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -1259,8 +1259,14 @@ static int config_parser_include(ConfigParser *parser, ConfigRoot *root, ConfigN
 
         r = open(node->include.file->path, O_RDONLY | O_CLOEXEC | O_NOCTTY);
         if (r < 0) {
-                if (errno == ENOENT || errno == ENOTDIR)
-                        return node->include.ignore_missing ? 0 : CONFIG_E_INVALID;
+                if (errno == ENOENT || errno == ENOTDIR) {
+                        if (node->include.ignore_missing)
+                                return 0;
+
+                        CONFIG_ERR(&parser->state, "Missing configuration file",
+                                   ": %s", node->include.file->path);
+                        return CONFIG_E_INVALID;
+                }
 
                 return error_origin(-errno);
         }


### PR DESCRIPTION
If we cannot open a configuration file, be more verbose about it. We
already log a lot about errors in configuration files, so this just adds
one more, which can hopefully help in diagnosing such errors more
easily.