### PR TITLE
util/selinux: Change auditing based on the log type.

### DIFF
--- a/src/util/audit-fallback.c
+++ b/src/util/audit-fallback.c
@@ -21,7 +21,7 @@ int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
         return util_drop_permissions(uid, gid);
 }
 
-int util_audit_log(const char *message, uid_t uid) {
+int util_audit_log(int type, const char *message, uid_t uid) {
         int r;
 
         r = fprintf(stderr, "%s\n", message);

--- a/src/util/audit.h
+++ b/src/util/audit.h
@@ -7,8 +7,14 @@
 #include <c-stdaux.h>
 #include <stdlib.h>
 
+enum {
+        UTIL_AUDIT_TYPE_NOAUDIT,
+        UTIL_AUDIT_TYPE_AVC,
+        UTIL_AUDIT_TYPE_SELINUX_ERROR,
+};
+
 int util_audit_drop_permissions(uint32_t uid, uint32_t gid);
-int util_audit_log(const char *message, uid_t uid);
+int util_audit_log(int type, const char *message, uid_t uid);
 
 int util_audit_init_global(void);
 void util_audit_deinit_global(void);


### PR DESCRIPTION
The SELinux log callback includes a message type.  Not all messages are
auditable and those that are don't have the different audit types.  Update
the auditing accordingly.

If the message is not auditable, write it to stderr.

Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>