### PR TITLE
util/audit: Revert UTIL_AUDIT_TYPE_SELINUX_ERROR audit type.

### DIFF
--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -108,9 +108,6 @@ int util_audit_log(int type, const char *message, uid_t uid) {
         case UTIL_AUDIT_TYPE_AVC:
                 audit_type = AUDIT_USER_AVC;
                 break;
-        case UTIL_AUDIT_TYPE_SELINUX_ERROR:
-                audit_type = AUDIT_USER_SELINUX_ERR;
-                break;
         case UTIL_AUDIT_TYPE_NOAUDIT:
         default:
                 audit_type = 0;

--- a/src/util/audit.h
+++ b/src/util/audit.h
@@ -10,7 +10,6 @@
 enum {
         UTIL_AUDIT_TYPE_NOAUDIT,
         UTIL_AUDIT_TYPE_AVC,
-        UTIL_AUDIT_TYPE_SELINUX_ERROR,
 };
 
 int util_audit_drop_permissions(uint32_t uid, uint32_t gid);

--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -300,9 +300,6 @@ static int bus_selinux_log(int type, const char *fmt, ...) {
         case SELINUX_AVC:
                 audit_type = UTIL_AUDIT_TYPE_AVC;
                 break;
-        case SELINUX_ERROR:
-                audit_type = UTIL_AUDIT_TYPE_SELINUX_ERROR;
-                break;
         default:
                 /* not an auditable message. */
                 audit_type = UTIL_AUDIT_TYPE_NOAUDIT;


### PR DESCRIPTION
After [discussions on the SELinux mail list](https://lore.kernel.org/selinux/CAEjxPJ6=s504ZdWevGALxxksCF4tsQ46meD8iCg7sCFoV9sKSA@mail.gmail.com/) related to the content of audit
messages that libselinux generates, it was determined that no
SELINUX_ERROR messages are auditable after all.  In the future, if there
are ones that need to be audited, they will have a different value in the
libselinux log callback and this can be restored.

Audit messages added in bus1/dbus-broker#240 are still appropriate.

Signed-off-by: Chris PeBenito <chpebeni@linux.microsoft.com>