### PR TITLE
dbus/socket: handle unexpected return of 1 from SIOCOUTQ

### DIFF
--- a/src/dbus/socket.c
+++ b/src/dbus/socket.c
@@ -743,7 +743,7 @@ static int socket_dispatch_write(Socket *socket) {
                 if (r < 0)
                         return error_origin(-errno);
 
-                if (v > 0) /* treat like EAGAIN */
+                if (v > 1) /* 1 not 0 as we may be 1/2 way through kernel sock_wfree(): treat like EAGAIN */
                         return 0;
 
                 c_list_for_each_entry_safe(buffer, safe, &socket->out.pending, link)


### PR DESCRIPTION
This fixes a problem we encountered where all messages to a single peer
became blocked while messages to other peers continued to be delivered.

After much tracing it was discovered that the socket associated with
that peer could get stuck in a state where dbus-broker was waiting for
an EPOLLOUT event that would never happen, because the kernel socket
buffer was already empty. The EPOLLOUT event that was generated when the
socket buffer became empty was effectively ignored.

The problem is caused by the use of the SIOCOUTQ ioctl() in
src/dbus/socket.c:socket_dispatch_write()...

Sometimes, after an EPOLLOUT notification from the kernel, which would
normally cause a pending message to be written to the socket, the
SIOCOUTQ ioctl returns 1 rather than 0. This causes dbus-broker to
assume that there is an outstanding message in the kernel buffer and
that it will receive another EPOLLOUT event when the buffer becomes
empty, so it refrains from writing and clears the cached EPOLLOUT event
using dispatch_file_clear(). The subsequent EPOLLOUT event that was
assumed would be coming never happens because in reality there is
nothing left to write in the socket buffer, and as epoll is used in
edge-driven mode (using EPOLLET), the socket never wakes up again for
writing and so the output queue is stalled.

Obviously 1 is an unlikely value for SIOCOUTQ, because dbus never sends
such short messages. The reason it is returning 1 is (probably) because
the kernel counter of the write space used (sk_wmem_alloc in struct
sock) is overloaded as a reference counter...

sk_wmem_alloc starts at 1 (a simple initial reference) and is
incremented by skb->truesize in skb_set_owner_w() when a packet is sent.
The 1 of the initial reference is subtracted in sk_wmem_alloc_get(), the
function that is called to implement SIOCOUTQ. The sock_wfree() function
decrements sk_wmem_alloc when an skb is destroyed and calls the
sk_write_space socket op, which is unix_write_space() for a unix domain
socket. unix_write_space() uses unix_writable() to determine if the
socket is writable and wakes up any pollers with EPOLLOUT if it is.

However, in order to avoid the possibility of a race condition,
sock_wfree() subtracts 1 from the amount that it decrements from
sk_wmem_alloc before it calls the sk_write_space op, thereby holding a
temporary reference. This reference is decremented from sk_wmem_alloc
after the sk_write_space call. So, if a task woken by unix_write_space()
performs the SIOCOUTQ ioctl() before the final decrement takes place, it
can be returned a value of 1 rather than 0, thereby giving the false
impression that there is still data waiting to be sent.

You could argue that this is a kernel bug. However, a simple fix is for
socket_dispatch_write() in dbus-broker to require the value returned by
SIOCOUTQ to be greater than 1 rather than greater than 0 before assuming
that there will be another EPOLLOUT event on the socket.

The temporary reference held by sock_wfree() has been in the kernel
since commit d99927f4d93f36553699573b279e0ff98ad7dea6, linux 2.6.32.
We've only encountered this issue on an ARMv8 system running on a
multiple core processor, but with only one core enabled. It has not been
encountered with the same software running on a single core ARMv5
system, or on a cut-down version of the software running on an x86_64
system. Presumably this discrepancy is due to scheduling differences.

That nobody else has reported this kernel bug (if that is what it is),
is probably because few application are brave enough to use epoll in
edge-triggered mode!