### PR TITLE
docs: fix simple typo, signalls -> signals

### DIFF
--- a/src/util/dispatch.c
+++ b/src/util/dispatch.c
@@ -165,7 +165,7 @@ void dispatch_file_deinit(DispatchFile *file) {
  *
  * Once you handled an event fully, you must clear it via dispatch_file_clear()
  * to tell the dispatcher that you should only be invoked for the event
- * when the kernel signalls it again.
+ * when the kernel signals it again.
  */
 void dispatch_file_select(DispatchFile *file, uint32_t mask) {
         c_assert(!(mask & ~file->kernel_mask));


### PR DESCRIPTION
There is a small typo in src/util/dispatch.c.

Should read `signals` rather than `signalls`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md