### PR TITLE
launch/service: track systemd unit state

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -729,6 +729,15 @@ int driver_name_activation_failed(Bus *bus, Activation *activation) {
         /* in case the name is activated again in the future, we should request it again */
         activation->requested = false;
 
+        /*
+         * NOTE: We can get activation-failure notifications by the launcher
+         *       even when the name was already claimed. The launcher tracks
+         *       services for their entire lifetime.
+         *       We don't really care for late notifications so far, since both
+         *       the queues are empty in this case. But we need to be aware of
+         *       this if we extend this in the future.
+         */
+
         c_list_for_each_entry_safe(request, request_safe, &activation->activation_requests, link) {
                 Peer *sender;
 

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -17,7 +17,9 @@ struct Service {
         bool not_found;
         bool running;
         bool reload_tag;
-        sd_bus_slot *slot;
+        sd_bus_slot *slot_watch_unit;
+        sd_bus_slot *slot_query_unit;
+        sd_bus_slot *slot_start_unit;
         CRBNode rb;
         CRBNode rb_by_name;
         char *path;


### PR DESCRIPTION
Track the `ActiveState` property of systemd units associated with dbus
services. This allows us to better track when a service activation fails
beyond just the `StartUnit()` call.

Until now we only ever tracked failure of the `StartUnit()` call itself.
However, this call does not wait for a service to be fully activated,
but merely waits for the start-job to be queued in systemd. This means,
we only see failures of the unit-verification and transaction checks,
but never get any results of the transaction itself.

In particular, this means that if any unit successfully spawns, but then
fails before claiming a bus-name, we never see this failure, because it
is reported only late by systemd.

This commit extends the launcher to track all systemd units we activate
for as long as a dbus-service is live. We only ever query the
`ActiveState` property, and thus can reliably track when a unit fails.
Note that we never track when a unit succeeds, because this information
is of no use in the launcher. Instead, we rely on the broker to
successfully track acquired names (which it already does). We only ever
tell the broker when a unit fails, and we now do that over the entire
lifetime of a dbus-service. This way, even late failures are reported
to the broker (which will ignore them, if they appeared after a service
already activated).