### PR TITLE
[PENDING] util/selinux: Add additional audit message types.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ dep_thread = dependency('threads')
 
 use_audit = get_option('audit')
 if use_audit
-        dep_libaudit = dependency('audit', version: '>=2.7')
+        dep_libaudit = dependency('audit', version: '>=3.0')
         dep_libcapng = dependency('libcap-ng', version: '>=0.6')
 endif
 
@@ -98,7 +98,7 @@ endif
 
 use_selinux = get_option('selinux')
 if use_selinux
-        dep_libselinux = dependency('libselinux', version: '>=2.5')
+        dep_libselinux = dependency('libselinux', version: '>=3.2')
 endif
 
 #

--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -108,6 +108,12 @@ int util_audit_log(int type, const char *message, uid_t uid) {
         case UTIL_AUDIT_TYPE_AVC:
                 audit_type = AUDIT_USER_AVC;
                 break;
+        case UTIL_AUDIT_TYPE_POLICYLOAD:
+                audit_type = AUDIT_USER_MAC_POLICY_LOAD;
+                break;
+        case UTIL_AUDIT_TYPE_MAC_STATUS:
+                audit_type = AUDIT_USER_MAC_STATUS;
+                break;
         case UTIL_AUDIT_TYPE_NOAUDIT:
         default:
                 audit_type = 0;

--- a/src/util/audit.h
+++ b/src/util/audit.h
@@ -10,6 +10,8 @@
 enum {
         UTIL_AUDIT_TYPE_NOAUDIT,
         UTIL_AUDIT_TYPE_AVC,
+        UTIL_AUDIT_TYPE_POLICYLOAD,
+        UTIL_AUDIT_TYPE_MAC_STATUS,
 };
 
 int util_audit_drop_permissions(uint32_t uid, uint32_t gid);

--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -300,6 +300,12 @@ static int bus_selinux_log(int type, const char *fmt, ...) {
         case SELINUX_AVC:
                 audit_type = UTIL_AUDIT_TYPE_AVC;
                 break;
+        case SELINUX_POLICYLOAD:
+                audit_type = UTIL_AUDIT_TYPE_POLICYLOAD;
+                break;
+        case SELINUX_SETENFORCE:
+                audit_type = UTIL_AUDIT_TYPE_MAC_STATUS;
+                break;
         default:
                 /* not an auditable message. */
                 audit_type = UTIL_AUDIT_TYPE_NOAUDIT;


### PR DESCRIPTION
I picked up the patch from @pebenito so we don't forget about it. The original PR was #240 and was closed automatically when we switched the main branch.

I also updated the `meson.build` dependency to the now released `audit-3.0`. Once that hits the bigger distro channels, I think we can merge this. I would like to wait for the `libselinux` release as well, but this seems like something we can carry with an `#ifndef` until they prep a new release.

Anyway, leaving this here so we don't forget about this.