### PR TITLE
Support old kernel without PR_CAP_AMBIENT

### DIFF
--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -82,7 +82,7 @@ int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
 
                 if (have_audit_write) {
                         r = prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_AUDIT_WRITE, 0, 0);
-                        if (r < 0)
+                        if (r < 0 && errno != EINVAL) // EINVAL indicates the kernel does not support PR_CAP_AMBIENT
                                 return error_origin(-errno);
                 }
         }


### PR DESCRIPTION
In summary, this PR in combination with https://github.com/stevegrubb/libcap-ng/pull/29, would make dbus-broker work with `<4.3` kernel.

I have a device with old 4.1 kernel that I cannot upgrade, and I was trying to run dbus_broker with --audit in fedora:33 container.

At the beginning the error looks like this:

```
ERROR util_audit_drop_permissions @ ../src/util/audit.c +81: Operation not permitted
```

I traced it down to `libcap-ng` and patched it to support older kernel: https://github.com/stevegrubb/libcap-ng/pull/29, then I get this:

```
ERROR util_audit_drop_permissions @ ../src/util/audit.c +86: Invalid argument
```

It turns out to be a single call to `prctl(PR_CAP_AMBIENT, ...)` in dbus-broker, which would fail with `EINVAL` for the same reason as libcap-ng failed previously.

This PR adds a special case to ignore `EINVAL` which happens on old kernels. In combination with other PR I made for `libcap-ng`, I was able to get dbus-broker to work on fc33 with 4.1.x kernel.

```
[root@UDM-Pro build]# uname -r
4.1.37-v1.8.6.2969-6a09c7c

[root@UDM-Pro build]# systemctl status dbus.service dbus.socket
● dbus-broker.service - D-Bus System Message Bus
     Loaded: loaded (/usr/lib/systemd/system/dbus-broker.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2021-02-03 05:37:36 UTC; 13s ago
TriggeredBy: ● dbus.socket
       Docs: man:dbus-broker-launch(1)
   Main PID: 22346 (dbus-broker-lau)
     Memory: 1.3M
     CGroup: /libpod_parent/libpod-8adfccb893792578fbf459b928068b26207ed78081a08ca9ca8cd54207befe95/system.slice/dbus-broker.service
             ├─22346 /usr/local/bin/dbus-broker-launch --scope system --audit
             └─22347 dbus-broker --log 4 --controller 9 --machine-id 5d7a0b05919e45828224a9d15d5604cc --max-bytes 536870912 --max-fds 4096 --max-match>

Feb 03 05:37:35 UDM-Pro systemd[1]: Starting D-Bus System Message Bus...
Feb 03 05:37:36 UDM-Pro systemd[1]: Started D-Bus System Message Bus.
Feb 03 05:37:36 UDM-Pro dbus-broker[22347]: Falling back to racy auxiliary groupsresolution using nss.
Feb 03 05:37:36 UDM-Pro dbus-broker-lau[22346]: Ready

● dbus.socket - D-Bus System Message Bus Socket
     Loaded: loaded (/usr/lib/systemd/system/dbus.socket; disabled; vendor preset: enabled)
     Active: active (running) since Wed 2021-02-03 05:37:23 UTC; 26s ago
   Triggers: ● dbus-broker.service
     Listen: /run/dbus/system_bus_socket (Stream)
     CGroup: /libpod_parent/libpod-8adfccb893792578fbf459b928068b26207ed78081a08ca9ca8cd54207befe95/system.slice/dbus.socket

Feb 03 05:37:23 UDM-Pro systemd[1]: Listening on D-Bus System Message Bus Socket.
```