### PR TITLE
broker: pass serial numbers with activations

### DIFF
--- a/docs/dbus-broker.rst
+++ b/docs/dbus-broker.rst
@@ -189,14 +189,22 @@ the broker. See the section below for a list of interfaces on the controller.
 |         **method** Release() -> ()
 |
 |         # Reset the activation state of this name. Any pending activation
-|         # requests are canceled.
-|         **method** Reset() -> ()
+|         # requests are canceled. The call requires a serial number to be
+|         # passed along. This must be the serial number received by the last
+|         # activation even on this name. Calls for other serial numbers are
+|         # silently ignored and considered stale.
+|         **method** Reset(**t** *serial*) -> ()
 |
 |         # This signal is sent whenever a client requests activation of this
 |         # name. Note that multiple activation requests are coalesced by the
 |         # broker. The controller can cancel outstanding requests via the
 |         # **Reset()** method.
-|         **signal** Activate()
+|         # The broker sends a serial number with the event. This number
+|         # represents the activation request and must be used when reacting
+|         # to the request with methods like *Reset()*. The serial number is
+|         # unique for each event, and is never reused. A serial number of 0
+|         # is never sent and considered invalid.
+|         **signal** Activate(**t** *serial*)
 |
 |     }
 | }

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -66,10 +66,10 @@ static int controller_name_new(ControllerName **namep, Controller *controller, c
 /**
  * controller_name_reset() - XXX
  */
-int controller_name_reset(ControllerName *name) {
+int controller_name_reset(ControllerName *name, uint64_t serial) {
         int r;
 
-        r = driver_name_activation_failed(&name->controller->broker->bus, &name->activation);
+        r = driver_name_activation_failed(&name->controller->broker->bus, &name->activation, serial);
         if (r)
                 return error_fold(r);
 
@@ -79,8 +79,8 @@ int controller_name_reset(ControllerName *name) {
 /**
  * controller_name_activate() - XXX
  */
-int controller_name_activate(ControllerName *name) {
-        return controller_dbus_send_activation(name->controller, name->path);
+int controller_name_activate(ControllerName *name, uint64_t serial) {
+        return controller_dbus_send_activation(name->controller, name->path, serial);
 }
 
 static int controller_reload_compare(CRBTree *t, void *k, CRBNode *rb) {
@@ -311,7 +311,7 @@ int controller_add_name(Controller *controller,
         if (r)
                 return error_trace(r);
 
-        r = activation_init(&name->activation, name_entry, user_entry);
+        r = activation_init(&name->activation, &controller->broker->bus, name_entry, user_entry);
         if (r)
                 return (r == ACTIVATION_E_ALREADY_ACTIVATABLE) ? CONTROLLER_E_NAME_IS_ACTIVATABLE : error_fold(r);
 

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -101,8 +101,8 @@ struct Controller {
 /* names */
 
 ControllerName *controller_name_free(ControllerName *name);
-int controller_name_reset(ControllerName *name);
-int controller_name_activate(ControllerName *name);
+int controller_name_reset(ControllerName *name, uint64_t serial);
+int controller_name_activate(ControllerName *name, uint64_t serial);
 
 C_DEFINE_CLEANUP(ControllerName *, controller_name_free);
 
@@ -144,7 +144,7 @@ ControllerListener *controller_find_listener(Controller *controller, const char 
 ControllerReload *controller_find_reload(Controller *controller, uint32_t serial);
 
 int controller_dbus_dispatch(Controller *controller, Message *message);
-int controller_dbus_send_activation(Controller *controller, const char *path);
+int controller_dbus_send_activation(Controller *controller, const char *path, uint64_t serial);
 int controller_dbus_send_reload(Controller *controller, User *user, uint32_t serial);
 int controller_dbus_send_environment(Controller *controller, const char * const *env, size_t n_env);
 

--- a/src/bus/activation.h
+++ b/src/bus/activation.h
@@ -13,6 +13,7 @@
 typedef struct Activation Activation;
 typedef struct ActivationMessage ActivationMessage;
 typedef struct ActivationRequest ActivationRequest;
+typedef struct Bus Bus;
 typedef struct Message Message;
 typedef struct Name Name;
 typedef struct NameOwner NameOwner;
@@ -43,11 +44,12 @@ struct ActivationMessage {
 };
 
 struct Activation {
+        Bus *bus;
         Name *name;
         User *user;
         CList activation_messages;
         CList activation_requests;
-        bool requested : 1;
+        uint64_t pending;
 };
 
 #define ACTIVATION_NULL(_x) {                                                   \
@@ -65,7 +67,7 @@ ActivationMessage *activation_message_free(ActivationMessage *message);
 
 /* activation */
 
-int activation_init(Activation *activation, Name *name, User *user);
+int activation_init(Activation *activation, Bus *bus, Name *name, User *user);
 void activation_deinit(Activation *activation);
 
 void activation_get_stats_for(Activation *activation,

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -50,6 +50,7 @@ struct Bus {
 
         uint64_t n_monitors;
         uint64_t listener_ids;
+        uint64_t activation_ids;
 
         Metrics metrics;
 };

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -63,7 +63,7 @@ enum {
         _DRIVER_E_MAX,
 };
 
-int driver_name_activation_failed(Bus *bus, Activation *activation);
+int driver_name_activation_failed(Bus *bus, Activation *activation, uint64_t serial);
 int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 int driver_reload_config_invalid(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 

--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -386,7 +386,12 @@ static int launcher_fork(Launcher *launcher, int fd_controller) {
 
 static int launcher_on_name_activate(Launcher *launcher, sd_bus_message *m, const char *id) {
         Service *service;
+        uint64_t serial;
         int r;
+
+        r = sd_bus_message_read(m, "t", &serial);
+        if (r < 0)
+                return error_origin(r);
 
         service = c_rbtree_find_entry(&launcher->services,
                                       service_compare,
@@ -403,7 +408,7 @@ static int launcher_on_name_activate(Launcher *launcher, sd_bus_message *m, cons
                 return 0;
         }
 
-        r = service_activate(service);
+        r = service_activate(service, serial);
         if (r)
                 return error_fold(r);
 

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -32,6 +32,7 @@ struct Service {
         uint64_t instance;
         uint64_t n_missing_unit;
         uint64_t n_masked_unit;
+        uint64_t last_serial;
         char id[];
 };
 
@@ -56,5 +57,5 @@ int service_compare(CRBTree *t, void *k, CRBNode *n);
 int service_compare_by_name(CRBTree *t, void *k, CRBNode *n);
 
 int service_add(Service *service);
-int service_activate(Service *service);
+int service_activate(Service *service, uint64_t serial);
 int service_remove(Service *service);


### PR DESCRIPTION
Extend the activation communication between broker and launcher to use
serial numbers. This allows us to discard stale activation failures and
closes a race condition where we would incorrectly fail new activations
immediately after a previous service exited.

@lucab @cgwalters