### PR TITLE
units: drop the ordering after sysinit.target

### DIFF
--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -2,7 +2,7 @@
 Description=D-Bus System Message Bus
 Documentation=man:dbus-broker-launch(1)
 DefaultDependencies=false
-After=dbus.socket sysinit.target
+After=dbus.socket
 Before=basic.target shutdown.target
 Requires=dbus.socket
 Conflicts=shutdown.target


### PR DESCRIPTION
It is causing significant delays during boot, see
https://bugzilla.redhat.com/show_bug.cgi?id=1976653.

Also, the justification for this ordering was a misunderstanding:

> Secondly, make sure to order after sysinit.target, so basic system
> setup is done before we start. This is especially important to make
> sure the launcher can resolve user names and read the disk.

Ordering after sysinit.target is not necessary to "read the disk". The
basic file system is established before services are started.  Some
other file systems may be mounted later, but system services should
not access those file systems. (In cases where they do,
RequiresMountsFor= may be used, but dbus-broker shouldn't require any
special paths, afaik). OTOH, sysinit.target is not enough to establish
lookup of arbitrary user names. After=nss-user-lookup.target would be
required, but that would create an even worse ordering loop, because
user lookups may require established network. sssd.service is ordered
before nss-user-lookup.target, but after basic.target.