### PR TITLE
Run user service in session.slice

### DIFF
--- a/src/units/user/dbus-broker.service.in
+++ b/src/units/user/dbus-broker.service.in
@@ -12,6 +12,7 @@ Type=notify
 Sockets=dbus.socket
 ExecStart=@bindir@/dbus-broker-launch --scope user
 ExecReload=@bindir@/busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
+Slice=session.slice
 
 [Install]
 Alias=dbus.service


### PR DESCRIPTION
Run user service in session.slice

The dbus-broker service should run in the session slice when running as
a user service.

From [DESKTOP_ENVIRONMENTS][1]:

> The purpose of this grouping is to assign different priorities to the
> applications. This could e.g. mean reserving memory to session
> processes, preferentially killing background tasks in out-of-memory
> situations or assigning different memory/CPU/IO priorities to ensure
> that the session runs smoothly under load.

And from man:systemd.special(7):

> session.slice
>  All essential services and applications required for the session
>  should use this slice. These are services that either cannot be
>  restarted easily or where latency issues may affect the interactivity
>  of the system and applications. This includes the display server,
>  screen readers and other services such as DBus or XDG portals. Such
>  services should be configured to be part of this slice by adding
>  Slice=session.slice to their unit files.  # Please enter the commit
>  message for your changes. Lines starting

Note that the DBus service itself is explicitly mentioned here. This
should reduce the priority of the portals when it comes to freeing up
resources. Having the broker get killed by the OOM or alike can
negatively affect the stability the desktop session.

[1]: https://systemd.io/DESKTOP_ENVIRONMENTS/