### PR TITLE
launcher: propagate readable error message on service activation failure

### DIFF
--- a/docs/dbus-broker.rst
+++ b/docs/dbus-broker.rst
@@ -189,9 +189,9 @@ the broker. See the section below for a list of interfaces on the controller.
 |         **method** Release() -> ()
 |
 |         # Reset the activation state of this name. Any pending activation
-|         # requests are canceled. The call requires a serial number to be
+|         # requests are cancelled. The call requires a serial number to be
 |         # passed along. This must be the serial number received by the last
-|         # activation even on this name. Calls for other serial numbers are
+|         # activation event on this name. Calls for other serial numbers are
 |         # silently ignored and considered stale.
 |         **method** Reset(**t** *serial*) -> ()
 |

--- a/docs/dbus-broker.rst
+++ b/docs/dbus-broker.rst
@@ -193,7 +193,26 @@ the broker. See the section below for a list of interfaces on the controller.
 |         # passed along. This must be the serial number received by the last
 |         # activation event on this name. Calls for other serial numbers are
 |         # silently ignored and considered stale.
-|         **method** Reset(**t** *serial*) -> ()
+|         # A org.bus1.DBus.Name.Error string is also passed, giving a hint
+|         # about the reason the activation was reset. The list is defined below.
+|         **method** Reset(**t** *serial*, **s** *error*) -> ()
+|
+|         # Activation request failed: a concurrent deactivation request is already in progress
+|         **error** *org.bus1.DBus.Name.Error.DestructiveTransaction*
+|         # Activation request failed: unknown unit
+|         **error** *org.bus1.DBus.Name.Error.UnknownUnit*
+|         # Activation request failed: unit is masked
+|         **error** *org.bus1.DBus.Name.Error.MaskedUnit*
+|         # Activation request failed: unit is invalid
+|         **error** *org.bus1.DBus.Name.Error.InvalidUnit*
+|         # Unit activation job succeeded, but the unit failed afterwards
+|         **error** *org.bus1.DBus.Name.Error.UnitFailure*
+|         # The startup job was valid, but it failed during activation
+|         **error** *org.bus1.DBus.Name.Error.StartupFailure*
+|         # The startup job was valid, but it was skipped during activation
+|         **error** *org.bus1.DBus.Name.Error.StartupSkipped*
+|         # Activation request cancelled: bus name was released
+|         **error** *org.bus1.DBus.Name.Error.NameReleased*
 |
 |         # This signal is sent whenever a client requests activation of this
 |         # name. Note that multiple activation requests are coalesced by the

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -66,10 +66,10 @@ static int controller_name_new(ControllerName **namep, Controller *controller, c
 /**
  * controller_name_reset() - XXX
  */
-int controller_name_reset(ControllerName *name, uint64_t serial) {
+int controller_name_reset(ControllerName *name, uint64_t serial, int bus1_error) {
         int r;
 
-        r = driver_name_activation_failed(&name->controller->broker->bus, &name->activation, serial);
+        r = driver_name_activation_failed(&name->controller->broker->bus, &name->activation, serial, bus1_error);
         if (r)
                 return error_fold(r);
 

--- a/src/bus/driver.h
+++ b/src/bus/driver.h
@@ -63,7 +63,7 @@ enum {
         _DRIVER_E_MAX,
 };
 
-int driver_name_activation_failed(Bus *bus, Activation *activation, uint64_t serial);
+int driver_name_activation_failed(Bus *bus, Activation *activation, uint64_t serial, int bus1_error);
 int driver_reload_config_completed(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 int driver_reload_config_invalid(Bus *bus, uint64_t sender_id, uint32_t reply_serial);
 


### PR DESCRIPTION
Example:

1) ConditionPathExists=/tmp/marker fails (note: with change in systemd to return `skipped`)
2) AssertPathExists=/tmp/marker fails
3) service immediately exits with failure before taking ownership of bus

```
root@image:~# busctl call com.ClientServerExample /com/ClientServerExample com.ClientServerExample Hello
Call failed: Could not activate remote peer: job result: skipped.
root@image:~# nano /etc/systemd/system/hello.service 
root@image:~# systemctl daemon-reload
root@image:~# busctl call com.ClientServerExample /com/ClientServerExample com.ClientServerExample Hello
Call failed: Could not activate remote peer: job result: assert.
root@image:~# nano /etc/systemd/system/hello.service 
root@image:~# systemctl daemon-reload
root@image:~# busctl call com.ClientServerExample /com/ClientServerExample com.ClientServerExample Hello
Call failed: Could not activate remote peer: job result: failed.
```

Does this sound sensible?

Fixes https://github.com/bus1/dbus-broker/issues/269