### PR TITLE
launcher: use new StartUnitWithFlags method if available 

### DIFF
--- a/src/launch/introspect.c
+++ b/src/launch/introspect.c
@@ -1,0 +1,96 @@
+/*
+ * Implements D-Bus introspection, allowing to check whether
+ * an object supports a given D-Bus interface. Used for backward
+ * compatibility checks.
+ */
+
+#include <expat.h>
+#include "launch/introspect.h"
+#include "util/error.h"
+#include "util/log.h"
+
+struct parse_params {
+    const char *interface_name;
+    bool *supported;
+};
+
+static void parser_begin_fn(void *userdata, const XML_Char *name, const XML_Char **attrs) {
+        struct parse_params *params = userdata;
+        const char *k, *v;
+
+        c_assert(params);
+        c_assert(params->interface_name);
+        c_assert(params->supported);
+
+        if (!attrs)
+                return;
+
+        if (strcmp(name, "method") != 0)
+                return;
+
+        while (*attrs) {
+                k = *(attrs++);
+                v = *(attrs++);
+
+                if (!k || !v)
+                        continue;
+
+                if (strcmp(k, "name") == 0 && strcmp(v, params->interface_name) == 0) {
+                        *params->supported = true;
+                        return;
+                }
+        }
+}
+
+int object_supports_interface(Launcher *launcher, const char *bus_name, const char *object, const char *interface_name) {
+        _c_cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *reply_xml = NULL;
+        bool supported = false;
+        XML_Parser parser;
+        const char *xml;
+        int r;
+        struct parse_params params = {
+                .interface_name = interface_name,
+                .supported = &supported,
+        };
+
+        c_assert(launcher);
+        c_assert(bus_name);
+        c_assert(object);
+        c_assert(interface_name);
+
+        r = sd_bus_call_method(launcher->bus_regular,
+                               bus_name,
+                               object,
+                               "org.freedesktop.DBus.Introspectable",
+                               "Introspect",
+                               &error, &reply_xml, NULL);
+        if (r < 0)
+                return error_origin(r);
+
+        r = sd_bus_message_read(reply_xml, "s", &xml);
+        if (r < 0)
+                return error_origin(r);
+
+        parser = XML_ParserCreate(NULL);
+        if (!parser)
+                return error_origin(-ENOMEM);
+
+        XML_SetUserData(parser, &params);
+        XML_SetElementHandler(parser, parser_begin_fn, NULL);
+
+        r = XML_Parse(parser, xml, strlen(xml), 1);
+        if (r != XML_STATUS_OK) {
+                log_append_here(&launcher->log, LOG_ERR, 0, NULL);
+                r = log_commitf(&launcher->log,
+                                "Parsing the Introspect XML of '%s' failed: %s\n",
+                                object,
+                                XML_ErrorString(XML_GetErrorCode(parser)));
+                if (r)
+                        return error_fold(r);
+
+                return error_origin(-EINVAL);
+        }
+
+        return supported;
+}

--- a/src/launch/introspect.h
+++ b/src/launch/introspect.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "launch/launcher.h"
+
+int object_supports_interface(Launcher *launcher, const char *bus_name, const char *object, const char *interface_name);

--- a/src/launch/launcher.h
+++ b/src/launch/launcher.h
@@ -42,6 +42,7 @@ struct Launcher {
         uint64_t max_fds;
         uint64_t max_matches;
         bool at_console;
+        bool systemd_supports_start_with_flags;
 };
 
 int launcher_new(Launcher **launcherp, int listen_fd, bool audit, const char *configfile, bool user_scope);

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -248,7 +248,7 @@ static int service_watch_jobs_handler(sd_bus_message *message, void *userdata, s
         if (!service->job || strcmp(path, service->job))
                 return 0;
 
-        if (!strcmp(result, "done") || !strcmp(result, "skipped")) {
+        if (!strcmp(result, "done")) {
                 /*
                  * Our job completed successfully. Make sure to stop watching
                  * it so the `ActiveState` handling will take effect.

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -556,13 +556,19 @@ static int service_start_unit(Service *service) {
                                            "org.freedesktop.systemd1",
                                            "/org/freedesktop/systemd1",
                                            "org.freedesktop.systemd1.Manager",
-                                           "StartUnit");
+                                           launcher->systemd_supports_start_with_flags ? "StartUnitWithFlags" : "StartUnit");
         if (r < 0)
                 return error_origin(r);
 
         r = sd_bus_message_append(method_call, "ss", service->unit, "replace");
         if (r < 0)
                 return error_origin(r);
+
+        if (launcher->systemd_supports_start_with_flags) {
+                r = sd_bus_message_append(method_call, "t", 0);
+                if (r < 0)
+                        return error_origin(r);
+        }
 
         r = sd_bus_call_async(launcher->bus_regular, &service->slot_start_unit, method_call, service_start_unit_handler, service, -1);
         if (r < 0)

--- a/src/meson.build
+++ b/src/meson.build
@@ -137,6 +137,7 @@ if use_launcher
         exe_dbus_broker_launch = executable(
                 'dbus-broker-launch',
                 [
+                        'launch/introspect.c',
                         'launch/main.c',
                         'launch/launcher.c',
                         'launch/service.c',


### PR DESCRIPTION
Check if the new method from systemd is available via Introspect(),
and if so use it.
This allows us to receive 'skipped' as the result when the service we
are trying to activate does not run because of a failed Condition
check, which would return a false 'done' with the older
StartUnit method, resulting in us just waiting for a unit to
show up that will never arrive.

Fixes #276

Requires new systemd interface from https://github.com/systemd/systemd/pull/21609 so opening as draft for now