### PR TITLE
ci: introduce CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,9 @@
+---
+# vi: ts=2 sw=2 et:
+name: "CodeQL config"
+
+disable-default-queries: false
+
+queries:
+  - name: Enable possibly useful queries which are disabled by default
+    uses: ./.github/codeql-custom.qls

--- a/.github/codeql-custom.qls
+++ b/.github/codeql-custom.qls
@@ -1,0 +1,35 @@
+---
+# vi: ts=2 sw=2 et syntax=yaml:
+#
+# Note: it is not recommended to directly reference the respective queries from
+#       the github/codeql repository, so we have to "dance" around it using
+#       a custom QL suite
+# See:
+#   - https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#running-additional-queries
+#   - https://github.com/github/codeql-action/issues/430#issuecomment-806092120
+#   - https://codeql.github.com/docs/codeql-cli/creating-codeql-query-suites/
+
+- import: codeql-suites/cpp-lgtm.qls
+  from: codeql/cpp-queries
+- include:
+    id:
+      - cpp/bad-strncpy-size
+      - cpp/declaration-hides-variable
+      - cpp/inconsistent-null-check
+      - cpp/mistyped-function-arguments
+      - cpp/nested-loops-with-same-variable
+      - cpp/sizeof-side-effect
+      - cpp/suspicious-pointer-scaling
+      - cpp/suspicious-pointer-scaling-void
+      - cpp/suspicious-sizeof
+      - cpp/unsafe-strcat
+      - cpp/unsafe-strncat
+      - cpp/unsigned-difference-expression-compared-zero
+      - cpp/unused-local-variable
+    tags:
+      - "security"
+      - "correctness"
+    severity: "error"
+- exclude:
+    id:
+      - cpp/fixme-comment

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,50 @@
+---
+# vi: ts=2 sw=2 et:
+name: "CodeQL"
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      actions: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['cpp']
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@cd783c8a29bdcf5a5c79c5137889e24651fa626c
+      with:
+        languages: ${{ matrix.language }}
+        config-file: ./.github/codeql-config.yml
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y update
+        sudo apt -y install dbus expat libaudit-dev libselinux-dev libsystemd-dev python3-pip
+        sudo pip3 install meson ninja
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@cd783c8a29bdcf5a5c79c5137889e24651fa626c
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@cd783c8a29bdcf5a5c79c5137889e24651fa626c


### PR DESCRIPTION
This commit introduces GitHub's CodeQL Action[0] which regularly scans
code for possible errors and vulnerabilities. I borrowed our custom
configs from the systemd repository, since they enable a couple of other
security-related checks which are disabled by default.

[0] https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning

---

The results are then shown in the PR (if the PR introduces new alerts) or in the Security tab for the general overview, e.g.:

https://github.com/mrc0mmand/dbus-broker/security/code-scanning?query=+pr%3A1+
or
https://github.com/systemd/systemd/security/code-scanning

One minor issue is that the CodeQL workflow processes files from submodules, but it doesn't show preview for them in the UI, e.g.:

![image](https://user-images.githubusercontent.com/679338/151206234-ae04e4a5-8380-4b08-8afe-a81d16fa350c.png)

However, the offending line is still discoverable from the alerts overview:

![image](https://user-images.githubusercontent.com/679338/151206339-8670c23c-8845-470d-b287-191016ca844e.png)

so it's not completely useless.

Anyway, this is just a proposal, if this is something which you don't deem useful, feel free to close this PR.