### PR TITLE
tests: fix an fd leak

### DIFF
--- a/test/dbus/test-fdstream.c
+++ b/test/dbus/test-fdstream.c
@@ -197,10 +197,11 @@ static int test_fd_stream_fn(DispatchFile *file) {
 }
 
 static void test_fd_stream(void) {
+        _c_cleanup_(c_closep) int fd = -1;
         _c_cleanup_(dispatch_context_deinit) DispatchContext d = DISPATCH_CONTEXT_NULL(d);
         _c_cleanup_(connection_deinit) Connection c = CONNECTION_NULL(c);
         _c_cleanup_(util_broker_freep) Broker *broker = NULL;
-        int r, fd;
+        int r;
 
         /*
          * This test connects a single client to the broker, performs a SASL


### PR DESCRIPTION
```
==365== FILE DESCRIPTORS: 6 open (3 std) at exit.
==365== Open AF_UNIX socket 7: <unknown>
==365==    at 0x4A4A8BB: socket (syscall-template.S:120)
==365==    by 0x40597C: util_broker_connect_fd (util-broker.c:558)
==365==    by 0x4033DC: test_fd_stream (test-fdstream.c:235)
==365==    by 0x403599: main (test-fdstream.c:284)
==365==
==365== Open AF_UNIX socket 6: <unknown>
==365==    at 0x4A4A8BB: socket (syscall-template.S:120)
==365==    by 0x40597C: util_broker_connect_fd (util-broker.c:558)
==365==    by 0x4033DC: test_fd_stream (test-fdstream.c:235)
==365==    by 0x403599: main (test-fdstream.c:284)
==365==
==365== Open AF_UNIX socket 5: <unknown>
==365==    at 0x4A4A8BB: socket (syscall-template.S:120)
==365==    by 0x40597C: util_broker_connect_fd (util-broker.c:558)
==365==    by 0x4033DC: test_fd_stream (test-fdstream.c:235)
==365==    by 0x403599: main (test-fdstream.c:284)
```