### PR TITLE
Drop '#include <libaudit.h>' from src/util/apparmor.c

### DIFF
--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -8,7 +8,6 @@
 
 #include <c-rbtree.h>
 #include <c-stdaux.h>
-#include <libaudit.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/apparmor.h>


### PR DESCRIPTION
This header does not seem to be required.
Tested with -Dapparmor=true and -Daudit=true/-Daudit=false.

Bug: https://bugs.gentoo.org/873082