### PR TITLE
launch/service: name transient units after desktop-spec

### DIFF
--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -658,7 +658,7 @@ static int service_start_transient_unit(Service *service) {
         if (r)
                 return error_fold(r);
 
-        r = asprintf(&unit, "dbus-%s-%s@%"PRIu64".service", unique_name, escaped_name, service->instance++);
+        r = asprintf(&unit, "app-dbus-%s@%s-%"PRIu64".service", escaped_name, unique_name, service->instance++);
         if (r < 0)
                 return error_origin(-errno);
 


### PR DESCRIPTION
The experimental desktop-integration specification [1] proposes a nameing scheme for the units of desktop applications. Try to implement this scheme.

Cc: @swick #302 

[1] https://systemd.io/DESKTOP_ENVIRONMENTS/