### PR TITLE
launch: delay service-start until matches are installed

### DIFF
--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -612,10 +612,6 @@ static int service_start_unit(Service *service) {
         _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *method_call = NULL;
         int r;
 
-        r = service_watch_jobs(service);
-        if (r)
-                return error_trace(r);
-
         r = service_watch_unit(service, service->unit);
         if (r)
                 return error_trace(r);
@@ -645,10 +641,6 @@ static int service_start_transient_unit(Service *service) {
         _c_cleanup_(c_freep) char *unit = NULL, *escaped_name = NULL;
         const char *unique_name;
         int r;
-
-        r = service_watch_jobs(service);
-        if (r)
-                return error_trace(r);
 
         r = sd_bus_get_unique_name(launcher->bus_regular, &unique_name);
         if (r < 0)
@@ -882,10 +874,18 @@ static int service_start(Service *service) {
         int r;
 
         if (service->unit) {
+                r = service_watch_jobs(service);
+                if (r)
+                        return error_trace(r);
+
                 r = service_start_unit(service);
                 if (r)
                         return error_trace(r);
         } else if (service->argc > 0) {
+                r = service_watch_jobs(service);
+                if (r)
+                        return error_trace(r);
+
                 r = service_start_transient_unit(service);
                 if (r)
                         return error_trace(r);

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -81,10 +81,13 @@ Service *service_free(Service *service) {
 
         c_rbnode_unlink(&service->rb_by_name);
         c_rbnode_unlink(&service->rb);
-        free(service->job);
-        free(service->active_unit);
+
         service_data_free(service->data);
         free(service->name);
+
+        free(service->job);
+        free(service->active_unit);
+
         service->slot_start_unit = sd_bus_slot_unref(service->slot_start_unit);
         service->slot_watch_unit = sd_bus_slot_unref(service->slot_watch_unit);
         service->slot_watch_jobs = sd_bus_slot_unref(service->slot_watch_jobs);

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -981,10 +981,8 @@ int service_activate(Service *service, uint64_t serial) {
         }
 
         r = service_start(service);
-        if (r) {
-                service_discard_activation(service);
-                return error_trace(r);
-        }
+        if (r)
+                return error_fold(r);
 
         return 0;
 }

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -98,53 +98,6 @@ static void log_append_service(Log *log, Service *service) {
         );
 }
 
-int service_compare(CRBTree *t, void *k, CRBNode *n) {
-        Service *service = c_container_of(n, Service, rb);
-
-        return strcmp(k, service->id);
-}
-
-int service_compare_by_name(CRBTree *t, void *k, CRBNode *n) {
-        Service *service = c_container_of(n, Service, rb_by_name);
-
-        return strcmp(k, service->name);
-}
-
-Service *service_free(Service *service) {
-        if (!service)
-                return NULL;
-
-        c_rbnode_unlink(&service->rb_by_name);
-        c_rbnode_unlink(&service->rb);
-
-        service_data_free(service->data);
-        free(service->name);
-
-        free(service->job);
-        free(service->active_unit);
-        service_data_free(service->active_data);
-
-        service->slot_start_unit = sd_bus_slot_unref(service->slot_start_unit);
-        service->slot_watch_unit = sd_bus_slot_unref(service->slot_watch_unit);
-        service->slot_watch_jobs = sd_bus_slot_unref(service->slot_watch_jobs);
-        free(service);
-
-        return NULL;
-}
-
-int service_update(Service *service, const char *path, const char *unit, size_t argc, char **argv, const char *user, uid_t uid) {
-        ServiceData *data;
-        int r;
-
-        r = service_data_new(&data, path, unit, user, uid, argc, argv);
-        if (r)
-                return error_fold(r);
-
-        service_data_free(service->data);
-        service->data = data;
-        return 0;
-}
-
 int service_new(Service **servicep,
                 Launcher *launcher,
                 const char *name,
@@ -185,6 +138,53 @@ int service_new(Service **servicep,
         *servicep = service;
         service = NULL;
         return 0;
+}
+
+Service *service_free(Service *service) {
+        if (!service)
+                return NULL;
+
+        c_rbnode_unlink(&service->rb_by_name);
+        c_rbnode_unlink(&service->rb);
+
+        service_data_free(service->data);
+        free(service->name);
+
+        free(service->job);
+        free(service->active_unit);
+        service_data_free(service->active_data);
+
+        service->slot_start_unit = sd_bus_slot_unref(service->slot_start_unit);
+        service->slot_watch_unit = sd_bus_slot_unref(service->slot_watch_unit);
+        service->slot_watch_jobs = sd_bus_slot_unref(service->slot_watch_jobs);
+        free(service);
+
+        return NULL;
+}
+
+int service_update(Service *service, const char *path, const char *unit, size_t argc, char **argv, const char *user, uid_t uid) {
+        ServiceData *data;
+        int r;
+
+        r = service_data_new(&data, path, unit, user, uid, argc, argv);
+        if (r)
+                return error_fold(r);
+
+        service_data_free(service->data);
+        service->data = data;
+        return 0;
+}
+
+int service_compare(CRBTree *t, void *k, CRBNode *n) {
+        Service *service = c_container_of(n, Service, rb);
+
+        return strcmp(k, service->id);
+}
+
+int service_compare_by_name(CRBTree *t, void *k, CRBNode *n) {
+        Service *service = c_container_of(n, Service, rb_by_name);
+
+        return strcmp(k, service->name);
 }
 
 static void service_discard_activation(Service *service) {

--- a/src/launch/service.c
+++ b/src/launch/service.c
@@ -616,10 +616,6 @@ static int service_start_unit(Service *service) {
         _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *method_call = NULL;
         int r;
 
-        r = service_watch_unit(service, service->active_unit);
-        if (r)
-                return error_trace(r);
-
         r = sd_bus_message_new_method_call(launcher->bus_regular, &method_call,
                                            "org.freedesktop.systemd1",
                                            "/org/freedesktop/systemd1",
@@ -643,10 +639,6 @@ static int service_start_transient_unit(Service *service) {
         Launcher *launcher = service->launcher;
         _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *method_call = NULL;
         int r;
-
-        r = service_watch_unit(service, service->active_unit);
-        if (r)
-                return error_trace(r);
 
         r = sd_bus_message_new_method_call(launcher->bus_regular, &method_call,
                                            "org.freedesktop.systemd1",
@@ -865,6 +857,10 @@ static int service_start(Service *service) {
 
         if (service->active_unit) {
                 r = service_watch_jobs(service);
+                if (r)
+                        return error_trace(r);
+
+                r = service_watch_unit(service, service->active_unit);
                 if (r)
                         return error_trace(r);
 

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -24,6 +24,7 @@ struct Service {
         uint64_t n_masked_unit;
 
         uint64_t last_serial;
+        ServiceData *active_data;
         char *active_unit;
         char *job;
 
@@ -84,3 +85,5 @@ int service_data_new(
 ServiceData *service_data_free(ServiceData *data);
 
 C_DEFINE_CLEANUP(ServiceData *, service_data_free);
+
+int service_data_duplicate(ServiceData *data, ServiceData **dupp);

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -69,8 +69,9 @@ int service_update(Service *service, const char *path, const char *unit, size_t 
 int service_compare(CRBTree *t, void *k, CRBNode *n);
 int service_compare_by_name(CRBTree *t, void *k, CRBNode *n);
 
-int service_add(Service *service);
 int service_activate(Service *service, uint64_t serial);
+
+int service_add(Service *service);
 int service_remove(Service *service);
 
 int service_data_new(

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -17,6 +17,7 @@ struct Service {
         bool not_found;
         bool running;
         bool reload_tag;
+        bool is_transient;
         sd_bus_slot *slot_watch_jobs;
         sd_bus_slot *slot_watch_unit;
         sd_bus_slot *slot_start_unit;
@@ -33,6 +34,7 @@ struct Service {
         uint64_t n_missing_unit;
         uint64_t n_masked_unit;
         uint64_t last_serial;
+        char *active_unit;
         char *job;
         char id[];
 };

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -11,6 +11,7 @@
 #include "launch/launcher.h"
 
 typedef struct Service Service;
+typedef struct ServiceData ServiceData;
 
 struct Service {
         Launcher *launcher;
@@ -23,13 +24,8 @@ struct Service {
         sd_bus_slot *slot_start_unit;
         CRBNode rb;
         CRBNode rb_by_name;
-        char *path;
         char *name;
-        char *unit;
-        size_t argc;
-        char **argv;
-        char *user;
-        uid_t uid;
+        ServiceData *data;
         uint64_t instance;
         uint64_t n_missing_unit;
         uint64_t n_masked_unit;
@@ -37,6 +33,16 @@ struct Service {
         char *active_unit;
         char *job;
         char id[];
+};
+
+struct ServiceData {
+        char *path;
+        char *unit;
+        char *user;
+        uid_t uid;
+
+        size_t argc;
+        char *argv[];
 };
 
 int service_new(Service **servicep,
@@ -62,3 +68,16 @@ int service_compare_by_name(CRBTree *t, void *k, CRBNode *n);
 int service_add(Service *service);
 int service_activate(Service *service, uint64_t serial);
 int service_remove(Service *service);
+
+int service_data_new(
+        ServiceData **datap,
+        const char *path,
+        const char *unit,
+        const char *user,
+        uid_t uid,
+        size_t argc,
+        char **argv
+);
+ServiceData *service_data_free(ServiceData *data);
+
+C_DEFINE_CLEANUP(ServiceData *, service_data_free);

--- a/src/launch/service.h
+++ b/src/launch/service.h
@@ -15,23 +15,26 @@ typedef struct ServiceData ServiceData;
 
 struct Service {
         Launcher *launcher;
-        bool not_found;
-        bool running;
-        bool reload_tag;
-        bool is_transient;
         sd_bus_slot *slot_watch_jobs;
         sd_bus_slot *slot_watch_unit;
         sd_bus_slot *slot_start_unit;
         CRBNode rb;
         CRBNode rb_by_name;
-        char *name;
-        ServiceData *data;
-        uint64_t instance;
         uint64_t n_missing_unit;
         uint64_t n_masked_unit;
+
         uint64_t last_serial;
         char *active_unit;
         char *job;
+
+        bool not_found;
+        bool running;
+        bool reload_tag;
+        bool is_transient;
+
+        char *name;
+        uint64_t instance;
+        ServiceData *data;
         char id[];
 };
 


### PR DESCRIPTION
This series delays the service-start until we correctly installed all matches. With #285 we now wait for `LoadUnit()` to return before installing our D-Bus matches, so we know the proper service object-paths. However, this change caused a race-condition where the service might spawn and fail faster than we can process the reply to `LoadUnit()`. This is quite unlikely, given that the `LoadUnit()` operation is scheduled first. However, with the coalesced message-transmissions of dbus-broker, the different messages we schedule are often transmitted in a single syscall and thus on slower machines this race is actually possible to hit.

Regardless, this needs to be fixed, so we simply delay the start-unit operation until the matches are installed. This series starts with a bunch of cleanups and then moves code around to make the series easier to review.

Additionally, given that we now delay access to `service->[argc,argv,unit]`, this series also properly caches the service-information and ensures we do not access changing data.

Possibly fixes #304.