### PR TITLE
enable dbus-broker reexecute

### DIFF
--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -216,7 +216,6 @@ static int controller_dispatch_connection(DispatchFile *file) {
 
         do {
                 _c_cleanup_(message_unrefp) Message *m = NULL;
-
                 r = connection_dequeue(&controller->connection, &m);
                 if (r) {
                         if (r == CONNECTION_E_EOF)
@@ -370,6 +369,22 @@ int controller_request_reload(Controller *controller,
                 return error_trace(r);
 
         reload = NULL;
+        return 0;
+}
+
+/**
+* controller_request_reexecute() - XXX
+*/
+int controller_request_reexecute(Controller *controller,
+                              User *sender_user,
+                              uint64_t sender_id,
+                              uint32_t sender_serial) {
+        int r;
+
+        r = controller_dbus_send_reexecute(controller, sender_user, sender_serial);
+        if (r)
+                return error_trace(r);
+
         return 0;
 }
 

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -153,6 +153,10 @@ int controller_request_reload(Controller *controller,
                               User *user,
                               uint64_t sender_id,
                               uint32_t sender_serial);
+int controller_request_reexecute(Controller *controller,
+                                 User *user,
+                                 uint64_t sender_id,
+                                 uint32_t sender_serial);
 ControllerName *controller_find_name(Controller *controller, const char *path);
 ControllerListener *controller_find_listener(Controller *controller, const char *path);
 ControllerReload *controller_find_reload(Controller *controller, uint32_t serial);
@@ -160,6 +164,7 @@ ControllerReload *controller_find_reload(Controller *controller, uint32_t serial
 int controller_dbus_dispatch(Controller *controller, Message *message);
 int controller_dbus_send_activation(Controller *controller, const char *path, uint64_t serial);
 int controller_dbus_send_reload(Controller *controller, User *user, uint32_t serial);
+int controller_dbus_send_reexecute(Controller *controller, User *user, uint32_t serial);
 int controller_dbus_send_environment(Controller *controller, const char * const *env, size_t n_env);
 
 C_DEFINE_CLEANUP(Controller *, controller_deinit);

--- a/src/broker/main.h
+++ b/src/broker/main.h
@@ -10,6 +10,7 @@
 enum {
         _MAIN_SUCCESS,
         MAIN_EXIT,
+        MAIN_REEXEC,
         MAIN_FAILED,
 };
 

--- a/src/bus/listener.c
+++ b/src/bus/listener.c
@@ -23,7 +23,8 @@ static int listener_dispatch(DispatchFile *file) {
         if (!(dispatch_file_events(file) & EPOLLIN))
                 return 0;
 
-        fd = accept4(listener->socket_fd, NULL, NULL, SOCK_CLOEXEC | SOCK_NONBLOCK);
+        /* Don't close fd after exec */
+        fd = accept4(listener->socket_fd, NULL, NULL, SOCK_NONBLOCK);
         if (fd < 0) {
                 if (errno == EAGAIN) {
                         /*
@@ -43,7 +44,8 @@ static int listener_dispatch(DispatchFile *file) {
                 }
         }
 
-        r = peer_new_with_fd(&peer, listener->bus, listener->policy, listener->guid, file->context, fd);
+        r = peer_new_with_fd(&peer, listener->bus, listener->policy, listener->guid,
+                             file->context, fd, -1);
         if (r == PEER_E_QUOTA || r == PEER_E_CONNECTION_REFUSED)
                 /*
                  * The user has too many open connections, or a policy disallows it to

--- a/src/bus/match.c
+++ b/src/bus/match.c
@@ -934,6 +934,13 @@ void match_owner_deinit(MatchOwner *owner) {
         c_assert(!c_list_is_linked(&owner->destinations_link));
 }
 
+void rule_string_deinit(CList *rule_string_list) {
+        RuleString *rs;
+        c_list_for_each_entry(rs, rule_string_list, rule_string_link) {
+                free(rs->rule_string);
+        }
+}
+
 /**
  * match_owner_get_stats() - XXX
  */

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -21,6 +21,7 @@ typedef struct MatchRegistryByPath MatchRegistryByPath;
 typedef struct MatchRegistry MatchRegistry;
 typedef struct MatchRule MatchRule;
 typedef struct MessageMetadata MessageMetadata;
+typedef struct RuleString RuleString;
 
 #define MATCH_RULE_LENGTH_MAX (1024UL) /* taken from dbus-daemon(1) */
 
@@ -161,6 +162,16 @@ struct MatchRegistry {
                 .monitor_tree = C_RBTREE_INIT,          \
         }
 
+struct RuleString {
+        char *rule_string;
+        CList rule_string_link;
+};
+
+#define RULE_STRING_INIT(_x) {                                          \
+                .rule_string = NULL,                                    \
+                .rule_string_link = C_LIST_INIT((_x).rule_string_link), \
+        }
+
 /* rules */
 
 MatchRule *match_rule_user_ref(MatchRule *rule);
@@ -175,6 +186,7 @@ C_DEFINE_CLEANUP(MatchRule *, match_rule_user_unref);
 
 void match_owner_init(MatchOwner *owner);
 void match_owner_deinit(MatchOwner *owner);
+void rule_string_deinit(CList *rule_string_list);
 
 void match_owner_get_stats(MatchOwner *owner, unsigned int *n_bytesp, unsigned int *n_matchesp);
 void match_owner_move(MatchOwner *to, MatchOwner *from);

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -8,6 +8,7 @@
 #include <c-stdaux.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include "broker/controller.h"
 #include "bus/match.h"
 #include "bus/name.h"
 #include "bus/policy.h"
@@ -75,6 +76,7 @@ struct Peer {
         MatchRegistry sender_matches;
         MatchRegistry name_owner_changed_matches;
         MatchOwner owned_matches;
+        CList rule_string_list;
         ReplyRegistry replies;
         ReplyOwner owned_replies;
 };
@@ -88,6 +90,7 @@ struct Peer {
                 .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),                             \
                 .name_owner_changed_matches = MATCH_REGISTRY_INIT((_x).name_owner_changed_matches),     \
                 .owned_matches = MATCH_OWNER_INIT((_x).owned_matches),                                  \
+                .rule_string_list = C_LIST_INIT((_x).rule_string_list),                                 \
                 .replies = REPLY_REGISTRY_INIT,                                                         \
                 .owned_replies = REPLY_OWNER_INIT((_x).owned_replies),                                  \
         }
@@ -99,7 +102,8 @@ struct PeerRegistry {
 
 #define PEER_REGISTRY_INIT {}
 
-int peer_new_with_fd(Peer **peerp, Bus *bus, PolicyRegistry *policy, const char guid[], DispatchContext *dispatcher, int fd);
+int peer_new_with_fd(Peer **peerp, Bus *bus, PolicyRegistry *policy, const char guid[],
+                     DispatchContext *dispatcher, int fd, int peer_id);
 Peer *peer_free(Peer *peer);
 
 int peer_dispatch(DispatchFile *file);
@@ -127,6 +131,8 @@ void peer_registry_init(PeerRegistry *registry);
 void peer_registry_deinit(PeerRegistry *registry);
 void peer_registry_flush(PeerRegistry *registry);
 Peer *peer_registry_find_peer(PeerRegistry *registry, uint64_t id);
+
+int peer_recover_with_fd(int mem_fd, ControllerListener *listener);
 
 static inline bool peer_is_registered(Peer *peer) {
         return peer->registered;

--- a/src/dbus/connection.c
+++ b/src/dbus/connection.c
@@ -244,7 +244,7 @@ int connection_dequeue(Connection *connection, Message **messagep) {
         size_t n_input;
         int r;
 
-        if (_c_unlikely_(!connection->authenticated)) {
+        if (_c_unlikely_(!connection->authenticated) && connection->recovered == 0) {
                 do {
                         r = socket_dequeue_line(&connection->socket, &input, &n_input);
                         if (r)

--- a/src/dbus/connection.h
+++ b/src/dbus/connection.h
@@ -33,6 +33,7 @@ struct Connection {
         SASLClient sasl_client;
 
         bool server : 1;
+        bool recovered : 1;
         bool authenticated : 1;
 };
 

--- a/src/dbus/socket.c
+++ b/src/dbus/socket.c
@@ -732,7 +732,7 @@ static int socket_dispatch_read(Socket *socket) {
                               charge_fds);
 }
 
-static int socket_dispatch_write(Socket *socket) {
+int socket_dispatch_write(Socket *socket) {
         SocketBuffer *buffer, *safe;
         struct mmsghdr msgs[SOCKET_MMSG_MAX];
         struct msghdr *msg;

--- a/src/dbus/socket.h
+++ b/src/dbus/socket.h
@@ -72,6 +72,7 @@ int socket_queue_line(Socket *socket, User *user, const char *line, size_t n);
 int socket_queue(Socket *socket, User *user, Message *message);
 
 int socket_dispatch(Socket *socket, uint32_t event);
+int socket_dispatch_write(Socket *socket);
 void socket_shutdown(Socket *socket);
 void socket_close(Socket *socket);
 void socket_get_stats(Socket *socket,

--- a/src/launch/launcher.h
+++ b/src/launch/launcher.h
@@ -29,6 +29,7 @@ struct Launcher {
         Log log;
         int fd_listen;
         bool audit;
+        int broker_reexecuted;
         bool user_scope;
         char *configfile;
         Dirwatch *dirwatch;
@@ -38,13 +39,16 @@ struct Launcher {
         uint64_t service_ids;
         uint32_t uid;
         uint32_t gid;
+        uint32_t controller_fd;
         uint64_t max_bytes;
         uint64_t max_fds;
         uint64_t max_matches;
+        pid_t broker_pid;
         bool at_console;
 };
 
-int launcher_new(Launcher **launcherp, int listen_fd, bool audit, const char *configfile, bool user_scope);
+int launcher_new(Launcher **launcherp, int listen_fd, bool audit, const char *configfile,
+                 bool user_scope, int controller_fd, int broker_pid);
 Launcher *launcher_free(Launcher *launcher);
 
 C_DEFINE_CLEANUP(Launcher *, launcher_free);

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,6 +40,7 @@ sources_bus = [
         'util/metrics.c',
         'util/misc.c',
         'util/proc.c',
+        'util/serialize.c',
         'util/sockopt.c',
         'util/string.c',
         'util/systemd.c',

--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -17,6 +17,8 @@ PrivateTmp=true
 PrivateDevices=true
 ExecStart=@bindir@/dbus-broker-launch --scope system --audit
 ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
+Restart=always
+RestartSec=1
 
 [Install]
 Alias=dbus.service

--- a/src/util/proc.c
+++ b/src/util/proc.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include "util/error.h"
 #include "util/proc.h"
+#include "util/serialize.h"
 
 int proc_get_seclabel(pid_t pid, char **labelp, size_t *n_labelp) {
         _c_cleanup_(c_fclosep) FILE *f = NULL;

--- a/src/util/serialize.c
+++ b/src/util/serialize.c
@@ -1,0 +1,150 @@
+/*
+* Serialize Helpers
+*/
+
+#include <c-rbtree.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include "bus/peer.h"
+#include "util/error.h"
+#include "util/proc.h"
+#include "util/serialize.h"
+#include "util/syscall.h"
+
+int state_file_init(FILE **ret) {
+        int mem_fd;
+        FILE *f = NULL;
+        mem_fd = syscall_memfd_create("launcher-state", 0);
+        if (mem_fd < 0)
+                return mem_fd;
+
+        errno = 0;
+        f = fdopen(mem_fd, "w+");
+        if (!f) {
+                return error_trace(-errno);
+        }
+        *ret = f;
+        return mem_fd;
+}
+
+int serialize_basic(FILE *f, char *key, const char *format, ...) {
+        va_list args;
+        _c_cleanup_(c_freep) char *buf = malloc(LINE_LENGTH_MAX);
+        int r;
+
+        va_start(args, format);
+        r = vsnprintf(buf, LINE_LENGTH_MAX, format, args);
+        va_end(args);
+
+        if (r < 0 || strlen(key) + r + 2 > LINE_LENGTH_MAX) {
+                return -EINVAL;
+        }
+
+        fputs(key, f);
+        fputc('=', f);
+        fputs(buf, f);
+        fputc('\n', f);
+
+        return 0;
+}
+
+int serialize_peers(FILE *f, Broker *broker) {
+        Peer *peeri;
+        int r = 0;
+
+        _c_cleanup_(c_freep) char *fd_str = malloc(FD_LENGTH_MAX), *id_str = malloc(ID_LENGTH_MAX);
+        _c_cleanup_(c_freep) char *pid_str = malloc(PID_LENGTH_MAX), *uid_str = malloc(UID_LENGTH_MAX);
+        _c_cleanup_(c_freep) char *rule_str = malloc(MATCH_RULE_LENGTH_MAX), *sasl_str = malloc(SASL_ELEMENT_LENGTH_MAX);
+        _c_cleanup_(c_freep) char *rule_str_list = malloc(LINE_LENGTH_MAX), *sasl_str_list = malloc(SASL_LENGTH_MAX);
+
+        c_rbtree_for_each_entry(peeri, &broker->bus.peers.peer_tree, registry_node) {
+                _c_cleanup_(c_freep) char *nameowner_ship_str = malloc(NAME_LENGTH_MAX);
+                memset(nameowner_ship_str, 0, NAME_LENGTH_MAX);
+                char *rule_str_list_cur = rule_str_list, *sasl_str_list_cur = sasl_str_list;
+                int left_length = LINE_LENGTH_MAX;
+                bool skip_this_peer = false;
+
+                /* Skip dbus-broker-launch */
+                if (peeri->pid == broker->launcher_pid) {
+                        close(peeri->connection.socket.fd);
+                        continue;
+                }
+
+                /* Serialize fd, id, pid and uid. */
+                (void) snprintf(fd_str, FD_LENGTH_MAX, "%d", peeri->connection.socket.fd);
+                (void) snprintf(id_str, ID_LENGTH_MAX, "%lu", peeri->id);
+                (void) snprintf(pid_str, PID_LENGTH_MAX, "%d", peeri->pid);
+                (void) snprintf(uid_str, UID_LENGTH_MAX, "%u", peeri->user->uid);
+                /* 1 * strlen('peer=') + 4 * strlen(';') + 1 * strlen('\0') = 10 */
+                left_length -= strlen(fd_str) + strlen(id_str) + strlen(pid_str) + strlen(uid_str) + 10;
+
+                /* Serialize requested names. */
+                NameOwnership *nameowner_shipi = NULL;
+                c_rbtree_for_each_entry(nameowner_shipi, &peeri->owned_names.ownership_tree, owner_node) {
+                        if (name_ownership_is_primary(nameowner_shipi) && nameowner_shipi->name->name){
+                                (void) snprintf(nameowner_ship_str, NAME_LENGTH_MAX, "%s", nameowner_shipi->name->name);
+                                left_length -= strlen(nameowner_ship_str) + strlen(";");
+                        }
+                }
+                /* Generate a owner name for peers which doesn't have one */
+                if (strlen(nameowner_ship_str) == 0) {
+                        snprintf(nameowner_ship_str, NAME_LENGTH_MAX, "local.client.%d", peeri->connection.socket.fd);
+                }
+
+                /* Serialize match rule strings. */
+                rule_str_list_cur = stpcpy(rule_str_list_cur, "[");
+                left_length -= 1;
+                RuleString *rsi;
+                c_list_for_each_entry(rsi, &peeri->rule_string_list, rule_string_link) {
+                        (void) snprintf(rule_str, MATCH_RULE_LENGTH_MAX, "{%s}", rsi->rule_string);
+                        char *arg0 = strstr(rule_str, "arg0");
+                        if (arg0 && !strncmp(arg0 + strlen("arg0"), "=':1", strlen("=':1"))) {
+                                continue;
+                        }
+                        rule_str_list_cur = stpcpy(rule_str_list_cur, rule_str);
+                        left_length -= strlen(rule_str);
+                        /* Besides the next rule_str, we should also keep MATCH_RULE_LENGTH_MAX
+                         * bytes for sasl_str. sasl_str usually doesn't need that much space,
+                         * just be sure. */
+                        if (left_length <= 2 * MATCH_RULE_LENGTH_MAX) {
+                                skip_this_peer = true;
+                                break;
+                        }
+                }
+
+                if (skip_this_peer) {
+                        log_append_here(&broker->log, LOG_WARNING, 0, NULL);
+                        r = log_commitf(&broker->log, "Failed to serialize perr: %s, skipping.\n",
+                                        nameowner_ship_str);
+                        if (r < 0)
+                                return error_fold(r);
+                        close(peeri->connection.socket.fd);
+                        continue;
+                }
+
+                rule_str_list_cur = stpcpy(rule_str_list_cur, "]");
+
+                /* Serialize SASL state and fds_allowed. */
+                sasl_str_list_cur = stpcpy(sasl_str_list_cur, "[");
+                (void) snprintf(sasl_str, SASL_ELEMENT_LENGTH_MAX, "{%d}", peeri->connection.sasl_server.state);
+                sasl_str_list_cur = stpcpy(sasl_str_list_cur, sasl_str);
+                (void) snprintf(sasl_str, SASL_ELEMENT_LENGTH_MAX, "{%d}", peeri->connection.sasl_server.fds_allowed);
+                sasl_str_list_cur = stpcpy(sasl_str_list_cur, sasl_str);
+                (void) snprintf(sasl_str, SASL_ELEMENT_LENGTH_MAX, "{%d}", peeri->connection.sasl_client.state);
+                sasl_str_list_cur = stpcpy(sasl_str_list_cur, sasl_str);
+                sasl_str_list_cur = stpcpy(sasl_str_list_cur, "]");
+
+                /* Write all. */
+                (void) serialize_basic(f, "peer", "%s;%s;%s;%s;%s;%s;%s",
+                                                  fd_str,
+                                                  id_str,
+                                                  pid_str,
+                                                  uid_str,
+                                                  nameowner_ship_str,
+                                                  rule_str_list,
+                                                  sasl_str_list);
+        }
+        return 0;
+}

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stdlib.h>
+#include "broker/broker.h"
+
+#define LINE_LENGTH_MAX 51200
+#define FD_LENGTH_MAX 12
+#define PID_LENGTH_MAX 12
+#define UID_LENGTH_MAX 12
+#define ID_LENGTH_MAX 21
+#define SASL_ELEMENT_LENGTH_MAX 5
+#define SASL_LENGTH_MAX 20
+#define NAME_LENGTH_MAX 256
+
+enum {
+        PEER_INDEX_FD,
+        PEER_INDEX_ID,
+        PEER_INDEX_PID,
+        PEER_INDEX_UID,
+        PEER_INDEX_NAME,
+        PEER_INDEX_MATCH_RULE,
+        PEER_INDEX_SASL,
+        _PEER_INDEX_MAX,
+};
+
+enum {
+        SASL_INDEX_SERVER_STATE,
+        SASL_INDEX_SERVER_FDSALLOWED,
+        SASL_INDEX_CLIENT_STATE,
+        _SASL_INDEX_MAX,
+};
+
+int state_file_init(FILE **ret);
+int serialize_basic(FILE *f, char *key, const char *format, ...);
+int serialize_peers(FILE *f, Broker *broker);

--- a/src/util/string.c
+++ b/src/util/string.c
@@ -55,3 +55,78 @@ int util_strtou64(uint64_t *valp, const char *string) {
 
         return 0;
 }
+
+void generate_args_string(bool valid_arg, char **ret, int size, int *cur_i, char *option, char *val) {
+        int i = *cur_i;
+
+        if (!valid_arg)
+                return;
+
+        if (i + 3 >= size)
+                return;
+
+        ret[i++] = option;
+        ret[i++] = val;
+        *cur_i = i;
+}
+
+/* This extract value in @string to @ret.
+@string: string splited by ";"
+@ret: value between ";""
+input example: 1;2;3
+output example: 1 => 2 => 3 (one by one) */
+char *extract_word_inlist(char *string, char **ret) {
+        int i = 0, length = strlen(string);
+        bool found_value = false;
+        while (i < length) {
+                if (string[i] != ';')
+                        found_value = true;
+                else {
+                        if (found_value)
+                                break;
+                        else {
+                                string++;
+                                length--;
+                                continue;
+                        }
+                }
+                i++;
+        }
+        if (!found_value) {
+                **ret = 0;
+                return NULL;
+        }
+        c_assert(i >= 0);
+        *ret = strncpy(*ret, string, i);
+        *(*ret + i) = '\0';
+        return string + i;
+}
+
+/* Like extract_word_inlist, see example below:
+input example: [{a}{b}{c}]
+output example: a => b => c (one by one). */
+char *extract_list_element(char *string, char **ret)
+{
+        if (!string || strlen(string) <= 2)
+                return NULL;
+        int i = 0, pi = 0;
+        bool valid_left = false;
+        while (i < strlen(string)) {
+                if (string[i] == '{') {
+                        pi = i + 1;
+                        valid_left = true;
+                } else if (string[i] == '}') {
+                        valid_left = (i == pi ? false : valid_left);
+                        if (valid_left)
+                                break;
+                }
+                i++;
+        }
+        if (!valid_left) {
+                **ret = 0;
+                return NULL;
+        }
+        c_assert(i >= pi);
+        *ret = strndup(string + pi, i - pi);
+        return string + i + 1;
+}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -17,6 +17,9 @@ enum {
 
 int util_strtou32(uint32_t *valp, const char *string);
 int util_strtou64(uint64_t *valp, const char *string);
+void generate_args_string(bool valid_arg, char **ret, int size, int *cur_i, char *option, char *val);
+char *extract_word_inlist(char *string, char **ret);
+char *extract_list_element(char *string, char **ret);
 
 /**
  * string_compare() - compare two strings

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -67,6 +67,12 @@ test('Client Lifetime', test_lifetime)
 test_matches = executable('test-matches', ['test-matches.c'], dependencies: [ dep_test ])
 test('Signals and Matches', test_matches)
 
+test_serialize = executable('test-serialize', ['test-serialize.c'], dependencies: [ dep_test ])
+test('Serialize and Deserialize', test_serialize)
+
+test_reexecute = executable('test-reexecute', ['test-reexecute.c'], dependencies: [ dep_test ])
+test('Reexecute', test_reexecute)
+
 if use_reference_test
         dbus_bin = dep_dbus.get_pkgconfig_variable('bindir') + '/dbus-daemon'
 

--- a/test/dbus/test-reexecute.c
+++ b/test/dbus/test-reexecute.c
@@ -1,0 +1,125 @@
+/*
+ * Reexecute Tests
+ */
+
+#undef NDEBUG
+#include <c-stdaux.h>
+#include <systemd/sd-bus.h>
+#include <unistd.h>
+#include "util-broker.h"
+#include "util/string.h"
+
+#define PATH_LENGTH_MAX 4096
+#define TEST_ARG_MAX 12
+
+static void test_send_reexecute() {
+        Broker *broker = NULL;
+        _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *test_bus = NULL, *listener_bus = NULL, *cmd_bus = NULL;
+        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *listener_message = NULL;
+        _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *reply = NULL;
+        const char *reply_str = NULL, *unique_name = NULL, *owner = NULL;
+        int r;
+
+        util_broker_new(&broker);
+        broker->test_reexec = true;
+        util_broker_spawn(broker);
+
+        pid_t pid = fork();
+        if (pid) {
+                /* Add Listener. */
+                create_broker_listener(broker);
+                /* Wait 1s to make sure broker has reexecuted. */
+                sleep(1);
+
+                r = sd_bus_new(&listener_bus);
+                c_assert(r >= 0);
+
+                r = sd_bus_set_fd(listener_bus, broker->lc_fd, broker->lc_fd);
+                c_assert(r >= 0);
+
+                r = sd_bus_start(listener_bus);
+                c_assert(r >= 0);
+
+                r = sd_bus_message_new_method_call(listener_bus, &listener_message, NULL,
+                                                   "/org/bus1/DBus/Broker", "org.bus1.DBus.Broker", "AddListener");
+                c_assert(r >= 0);
+
+                r = sd_bus_message_append(listener_message, "oh", "/org/bus1/DBus/Listener/0", broker->listener_fd);
+                c_assert(r >= 0);
+
+                r = util_append_policy(listener_message);
+                c_assert(r >= 0);
+
+                r = sd_bus_call(listener_bus, listener_message, -1, NULL, NULL);
+                c_assert(r >= 0);
+
+                return 0;
+        }
+
+        /* Request name before reexecuting. */
+        {
+                util_broker_connect(broker, &test_bus);
+                r = sd_bus_get_unique_name(test_bus, &unique_name);
+                c_assert(r >= 0);
+                r = sd_bus_call_method(test_bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "RequestName", NULL, NULL, "su", "com.example.foo", 0);
+                c_assert(r >= 0);
+        }
+
+        /* Make broker reexecute. */
+        {
+                util_broker_connect(broker, &cmd_bus);
+                r = sd_bus_call_method(cmd_bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "Reexecute", NULL, &reply, "");
+                c_assert(r >= 0);
+
+                r = sd_bus_message_read(reply, "s", &reply_str);
+                c_assert(r >= 0);
+                c_assert(!strcmp(reply_str, "OK"));
+
+                sd_bus_flush_close_unref(cmd_bus);
+        }
+
+        /* GetNameOwner after reexecuting. */
+        {
+                r = sd_bus_call_method(test_bus, "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
+                                       "GetNameOwner", NULL, &reply, "s", "com.example.foo");
+                c_assert(r >= 0);
+
+                r = sd_bus_message_read(reply, "s", &owner);
+                c_assert(r >= 0);
+                c_assert(!strcmp(owner, unique_name));
+        }
+
+        c_assert(r >= 0);
+}
+
+static void test_generate_args_string() {
+        char *args[TEST_ARG_MAX];
+        for (int i = 0; i < TEST_ARG_MAX; i++) {
+                args[i] = NULL;
+        }
+        int i = 0;
+        generate_args_string(false, args, TEST_ARG_MAX, &i, "--log", "1");
+        c_assert(i == 0 && args[i] == NULL);
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--controller", "2");
+        c_assert(i == 2 && !strcmp(args[0], "--controller") && !strcmp(args[1], "2"));
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--machine-id", "3");
+        c_assert(i == 4 && !strcmp(args[2], "--machine-id") && !strcmp(args[3], "3"));
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--max-bytes", "123456");
+        c_assert(i == 6 && !strcmp(args[4], "--max-bytes") && !strcmp(args[5], "123456"));
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--max-fds", "12");
+        c_assert(i == 8 && !strcmp(args[6], "--max-fds") && !strcmp(args[7], "12"));
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--max-matches", "12345abcde");
+        c_assert(i == 10 && !strcmp(args[8], "--max-matches") && !strcmp(args[9], "12345abcde"));
+        generate_args_string(true, args, TEST_ARG_MAX, &i, "--reexec", "13");
+        c_assert(i == 10 && args[10] == NULL && args[11] == NULL);
+}
+
+int main(int argc, char **argv) {
+        test_generate_args_string();
+        /* Reexecute can only be run under privileged user */
+        if (getuid() == 0)
+                test_send_reexecute();
+        return 0;
+}

--- a/test/dbus/test-serialize.c
+++ b/test/dbus/test-serialize.c
@@ -1,0 +1,99 @@
+/*
+ * Serialize and Deserialize Tests
+ */
+
+#undef NDEBUG
+#include <c-stdaux.h>
+#include <stdlib.h>
+#include "util/serialize.h"
+#include "util/string.h"
+
+static void test_basic() {
+        FILE *f = NULL;
+        _c_cleanup_(c_freep) char *buf = malloc(LINE_LENGTH_MAX);
+        int mem_fd;
+
+        mem_fd = state_file_init(&f);
+        c_assert(mem_fd > 0);
+
+        c_assert(!serialize_basic(f, "test_u", "%u", 1234));
+        c_assert(!serialize_basic(f, "test_d", "%d", -1234));
+        c_assert(!serialize_basic(f, "test_s", "%s", "test"));
+        c_assert(!serialize_basic(f, "test_uds", "%u;%d;%s", 1234, -1234, "test"));
+
+        fseeko(f, 0, SEEK_SET);
+
+        if (fgets(buf, LINE_LENGTH_MAX, f) != NULL)
+                c_assert(!strcmp(buf, "test_u=1234\n"));
+        if (fgets(buf, LINE_LENGTH_MAX, f) != NULL)
+                c_assert(!strcmp(buf, "test_d=-1234\n"));
+        if (fgets(buf, LINE_LENGTH_MAX, f) != NULL)
+                c_assert(!strcmp(buf, "test_s=test\n"));
+        if (fgets(buf, LINE_LENGTH_MAX, f) != NULL)
+                c_assert(!strcmp(buf, "test_uds=1234;-1234;test\n"));
+
+        c_assert(!fgets(buf, LINE_LENGTH_MAX, f));
+}
+
+static void test_extract_world_inlist() {
+        char *list1 = ";;a;b;;c;;;";
+        char *list2 = "a;;bb;ccc;;;";
+        char *res1[] = {"a", "b", "c"};
+        char *res2[] = {"a", "bb", "ccc"};
+        char *res = malloc(10);
+
+        int i = 0;
+        while (true) {
+                list1 = extract_word_inlist(list1, &res);
+                if (!list1)
+                        break;
+                c_assert(!strcmp(res, res1[i++]));
+        }
+
+        i = 0;
+        while (true) {
+                list2 = extract_word_inlist(list2, &res);
+                if (!list2)
+                        break;
+                c_assert(!strcmp(res, res2[i++]));
+        }
+}
+
+static void test_extract_list_element() {
+        char *list1 = "[{}]";
+        char *list2 = "[{a}{b}{c}]";
+        char *list3 = "[{a}{{{b}}{}}{c}]";
+        char *res2_3[] = {"a", "b", "c"};
+        char *res = malloc(10);
+
+        int i = 0;
+        while (true) {
+                list1 = extract_list_element(list1, &res);
+                if (!list1)
+                        break;
+                c_assert(!res);
+        }
+
+        i = 0;
+        while (true) {
+                list2 = extract_list_element(list2, &res);
+                if (!list2)
+                        break;
+                c_assert(!strcmp(res, res2_3[i++]));
+        }
+
+        i = 0;
+        while (true) {
+                list3 = extract_list_element(list3, &res);
+                if (!list3)
+                       break;
+                c_assert(!strcmp(res, res2_3[i++]));
+        }
+}
+
+int main(int argc, char **argv) {
+        test_basic();
+        test_extract_world_inlist();
+        test_extract_list_element();
+        return 0;
+}

--- a/test/dbus/util-broker.h
+++ b/test/dbus/util-broker.h
@@ -20,6 +20,8 @@ struct Broker {
         pthread_t thread;
         struct sockaddr_un address;
         socklen_t n_address;
+        bool test_reexec;
+        int lc_fd; /* launcher controller fd */
         int listener_fd;
         int pipe_fds[2];
         pid_t pid;
@@ -29,6 +31,8 @@ struct Broker {
 #define BROKER_NULL {                                                           \
                 .address.sun_family = AF_UNIX,                                  \
                 .n_address = sizeof(struct sockaddr_un),                        \
+                .test_reexec = false,                                           \
+                .lc_fd = -1,                                                    \
                 .listener_fd = -1,                                              \
                 .pipe_fds[0] = -1,                                              \
                 .pipe_fds[1] = -1,                                              \
@@ -37,7 +41,9 @@ struct Broker {
 /* misc */
 
 void util_event_new(sd_event **eventp);
-void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp);
+int util_append_policy(sd_bus_message *m);
+int create_broker_listener(Broker *broker);
+void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp, bool is_reexec, int *lc_fd);
 void util_fork_daemon(sd_event *event, int pipe_fd, pid_t *pidp);
 
 /* broker */


### PR DESCRIPTION
This add a new feature to dbus-broker.  With this patch, we can reexecute dbus-broker by running `dbus-broker-launch --reexec`.

The main idea behind this commit is: 

1. **Serialize:** when broker gets the `Reexecute` message, it will serialize the main information (socket fd, id, uid, pid, match rule, request name, sasl) to the anonymous file, 
2. **Reexecute:** launcher and broker reexecute.
3. **AddListener:** when launcher has reexecuted successfully, it will send `AddListener` to broker.
4. **Recover:** broker recovers all peers when processing `AddListener` message, and it uses the `socket fd` saved in anonymous file to create new peers, and recover id/uid/pid/...
5. **Ready:** launcher will broadcast `Ready` signal, when the `dbus-broker-launch --reexec` gets this signal, the reexecuting process is over.

I'll split this commit to several small commits after your first review. Please take a look, thank a lot.