### PR TITLE
use PID FD if available from SO_PEERPIDFD, and return it via GetConnectionCredentials()

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -117,6 +117,10 @@ int broker_new(Broker **brokerp, const char *machine_id, int log_fd, int control
         if (r)
                 return error_fold(r);
 
+        r = sockopt_get_peerpidfd(controller_fd, &broker->bus.pid_fd);
+        if (r < 0)
+                return error_fold(r);
+
         r = dispatch_context_init(&broker->dispatcher);
         if (r)
                 return error_fold(r);

--- a/src/bus/bus.c
+++ b/src/bus/bus.c
@@ -55,6 +55,7 @@ void bus_deinit(Bus *bus) {
         bus->n_gids = 0;
         bus->gids = c_free(bus->gids);
         bus->pid = 0;
+        bus->pid_fd = c_close(bus->pid_fd);
         bus->user = user_unref(bus->user);
         metrics_deinit(&bus->metrics);
         peer_registry_deinit(&bus->peers);

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -36,6 +36,7 @@ struct Bus {
         Log *log;
         User *user;
         pid_t pid;
+        int pid_fd;
         gid_t *gids;
         size_t n_gids;
         char *seclabel;
@@ -57,6 +58,7 @@ struct Bus {
 };
 
 #define BUS_NULL(_x) {                                                          \
+                .pid_fd = -1,                                                   \
                 .users = USER_REGISTRY_NULL,                                    \
                 .names = NAME_REGISTRY_INIT,                                    \
                 .wildcard_matches = MATCH_REGISTRY_INIT((_x).wildcard_matches), \

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -259,6 +259,7 @@ int peer_new_with_fd(Peer **peerp,
         _c_cleanup_(user_unrefp) User *user = NULL;
         _c_cleanup_(c_freep) gid_t *gids = NULL;
         _c_cleanup_(c_freep) char *seclabel = NULL;
+        _c_cleanup_(c_closep) int pid_fd = -1;
         CRBNode **slot, *parent;
         size_t n_seclabel, n_gids = 0;
         struct ucred ucred;
@@ -281,6 +282,10 @@ int peer_new_with_fd(Peer **peerp,
         if (r)
                 return error_trace(r);
 
+        r = sockopt_get_peerpidfd(fd, &pid_fd);
+        if (r < 0)
+                return error_trace(r);
+
         peer = calloc(1, sizeof(*peer));
         if (!peer)
                 return error_origin(-ENOMEM);
@@ -290,6 +295,8 @@ int peer_new_with_fd(Peer **peerp,
         peer->user = user;
         user = NULL;
         peer->pid = ucred.pid;
+        peer->pid_fd = pid_fd;
+        pid_fd = -1;
         peer->gids = gids;
         gids = NULL;
         peer->n_gids = n_gids;
@@ -350,6 +357,7 @@ Peer *peer_free(Peer *peer) {
 
         fd = peer->connection.socket.fd;
 
+        c_close(peer->pid_fd);
         reply_owner_deinit(&peer->owned_replies);
         reply_registry_deinit(&peer->replies);
         match_owner_deinit(&peer->owned_matches);

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -56,6 +56,7 @@ struct Peer {
         Bus *bus;
         User *user;
         pid_t pid;
+        int pid_fd;
         gid_t *gids;
         size_t n_gids;
         char *seclabel;


### PR DESCRIPTION
This wires up support for PID FDs on Linux, which allow to pin a process by file descriptor. PIDs can be reused, and attackers can thus impersonate other processes. The new SO_PEERPIDFD socket option lets us get an FD that we know for sure pins the original process, so we return it as ProcessFD in GetConnectionCredentials() so that clients can use it as well.
If the new call is not available, pin the process manually by pid, so that we can still improve the situation a little by resolving the PID on the fly for internal usage, but in this case avoid returning the FD to clients, as it's not deemed safe enough.

dbus-daemon and spec PR: https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/398
polkit PR to use the new methods: https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/154
kernel patches to add SO_PEERPIDFD: https://lore.kernel.org/lkml/20230327-pidfd-file-api-v1-3-5c0e9a3158e4@kernel.org/T/#m159b013707a718dadde07e76f72f04153392a9cd