### PR TITLE
dbus-broker: pull in by multi-user.target properly

### DIFF
--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -20,3 +20,4 @@ ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.f
 
 [Install]
 Alias=dbus.service
+WantedBy=multi-user.target


### PR DESCRIPTION
So far nothing pulls in dbus-broker.service while the system is up, it's purely started via socket activation from dbus.socket. Which works fine in most ways, but is problematic when it comes to "systemctl isolate", which terminates all units nothing pulls in. Because without anything pulling in it will then be terminated even if its used in the current state and in the destination state.

This uses "multi-user.target" for pulling in the unit, which is the target unit that every regular boot (i.e. beyond "single-user mode") pulls in. (or with other words: in single user mode, we don't really need this, hence don't pull it in)

Fixes: https://github.com/systemd/systemd/issues/22022