### PR TITLE
selinux: support permissive mode

### DIFF
--- a/src/util/selinux-fallback.c
+++ b/src/util/selinux-fallback.c
@@ -16,6 +16,10 @@ bool bus_selinux_is_enabled(void) {
         return false;
 }
 
+bool bus_selinux_is_enforcing(void) {
+        return false;
+}
+
 const char *bus_selinux_policy_root(void) {
         return NULL;
 }

--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -39,6 +39,22 @@ bool bus_selinux_is_enabled(void) {
 }
 
 /**
+ * bus_selinux_is_enforcing() - checks if SELinux is in enforcing mode
+ *
+ * If selinux is not enabled or otherwise unavailable, this will return true.
+ * That is, this will only return false, if selinux is enabled and in
+ * permissive mode.
+ *
+ * Returns: true if SELinux is in enforcing mode, false otherwise.
+ */
+bool bus_selinux_is_enforcing(void) {
+        if (bus_selinux_status_open)
+                return selinux_status_getenforce() != 0;
+        else
+                return security_getenforce() != 0;
+}
+
+/**
  * bus_selinux_policy_root() - the root directory where the current SELinux policy can be found
  *
  * The current SELinux policy can be found in a different directory depending on the

--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -242,7 +242,7 @@ int bus_selinux_check_own(BusSELinuxRegistry *registry,
                                  "dbus",
                                  "acquire_svc",
                                  NULL);
-        if (r < 0) {
+        if (r < 0 && bus_selinux_is_enforcing()) {
                 /*
                  * Treat unknown contexts (possibly due to policy reload)
                  * as access denied.
@@ -289,7 +289,7 @@ int bus_selinux_check_send(BusSELinuxRegistry *registry,
                                  "dbus",
                                  "send_msg",
                                  NULL);
-        if (r < 0) {
+        if (r < 0 && bus_selinux_is_enforcing()) {
                 /*
                  * Treat unknown contexts (possibly due to policy reload)
                  * as access denied.

--- a/src/util/selinux.h
+++ b/src/util/selinux.h
@@ -16,6 +16,7 @@ enum {
 };
 
 bool bus_selinux_is_enabled(void);
+bool bus_selinux_is_enforcing(void);
 const char *bus_selinux_policy_root(void);
 
 int bus_selinux_registry_new(BusSELinuxRegistry **registryp, const char *fallback_context);


### PR DESCRIPTION
Add support for selinux permissive mode. Since we use `selinux_check_access()` rather than the deprecated direct AVC queries (which dbus-daemon uses), we don't get the automatic enforcing-mode check of the AVC helpers. Instead, we have to manually query `security_getenforce()` to get the value.

This implementation is modeled similar to the implementation in systemd (src/core/selinux-access.c). It uses a similar optimization via the status-page to avoid an additional syscall on each policy check.

Reported in #315.