### PR TITLE
launcher/config: use AT_RANDOM for libexpat hash seeds

### DIFF
--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -1230,6 +1230,7 @@ void config_parser_init(ConfigParser *parser) {
         *parser = (ConfigParser)CONFIG_PARSER_NULL(*parser);
 
         parser->xml = XML_ParserCreate(NULL);
+        c_assert(parser->xml);
 }
 
 /**

--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -6,8 +6,9 @@
 
 #include <c-list.h>
 #include <c-stdaux.h>
-#include <expat.h>
 #include <stdlib.h>
+
+struct XML_ParserStruct;
 
 typedef struct ConfigPath ConfigPath;
 typedef struct ConfigNode ConfigNode;
@@ -218,7 +219,7 @@ struct ConfigRoot {
         }
 
 struct ConfigParser {
-        XML_Parser xml;
+        struct XML_ParserStruct *xml;
 
         struct ConfigState {
                 NSSCache *nss;

--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -220,6 +220,7 @@ struct ConfigRoot {
 
 struct ConfigParser {
         struct XML_ParserStruct *xml;
+        unsigned long salt;
 
         struct ConfigState {
                 NSSCache *nss;


### PR DESCRIPTION
A small series with 2 minor fixes to the libexpat handling, and finally a workaround to forward AT_RANDOM to libexpat, rather than making libexpat fetch its own entropy from the kernel.

Cc: @agners #319 