### PR TITLE
memfd: provide proper abstractions

### DIFF
--- a/src/launch/test-config.c
+++ b/src/launch/test-config.c
@@ -9,7 +9,7 @@
 #include "launch/config.h"
 #include "launch/nss-cache.h"
 #include "util/dirwatch.h"
-#include "util/syscall.h"
+#include "util/misc.h"
 
 static const char *test_type2str[_CONFIG_NODE_N] = {
         [CONFIG_NODE_BUSCONFIG]         = "busconfig",
@@ -40,7 +40,7 @@ static int config_memfd(const char *data) {
         ssize_t n;
         int fd;
 
-        fd = syscall_memfd_create("dbus-broker-test-config", 0);
+        fd = misc_memfd("dbus-broker-test-config", MISC_MFD_NOEXEC_SEAL, 0);
         c_assert(fd >= 0);
         n = write(fd, data, strlen(data));
         c_assert(n == (ssize_t)strlen(data));

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -5,11 +5,183 @@
  */
 
 #include <c-stdaux.h>
+#include <fcntl.h>
 #include <grp.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "util/error.h"
 #include "util/misc.h"
+#include "util/syscall.h"
+
+#ifdef F_LINUX_SPECIFIC_BASE
+#  define MISC_F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
+#  define MISC_F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
+#else
+#  define MISC_F_ADD_SEALS (1024 + 9)
+#  define MISC_F_GET_SEALS (1024 + 10)
+#endif
+
+/**
+ * misc_memfd() - create non-executable memfd
+ * @name:       name for memfd inode
+ * @uflags:     memfd flags
+ * @useals:     initial seals
+ *
+ * This is a convenience wrapper around `memfd_create(2)`. It creates a memfd
+ * and returns it. However, a set of additional rules apply:
+ *
+ *  * The caller must specify either `MFD_EXEC` or `MFD_NOEXEC_SEAL`. This
+ *    is enforced. If the kernel does not support the flags, this will strip
+ *    them and manually edit the executable bit on the inode. Unfortunately,
+ *    `F_SEAL_EXEC` will then not be available. If required, you must set it
+ *    explicitly in @seals to ensure the call fails on older kernels. You
+ *    likely then also want `F_SEAL_SEAL` and `MFD_ALLOW_SEALING`, though.
+ *
+ *    IOW, if you require `F_SEAL_EXEC`, you likely need:
+ *
+ *        misc_memfd(
+ *              "...",
+ *              MISC_MFD_ALLOW_SEALING | MISC_MFD_NOEXEC_SEAL,
+ *              MISC_F_SEAL_EXEC
+ *        );
+ *
+ *    Throw in `MFD_CLOEXEC` or `F_SEAL_SEAL` as required.
+ *
+ *  * If `MFD_NOEXEC_SEAL` is used without `MFD_ALLOW_SEALING`, sealing will
+ *    be disabled (even though the kernel implicitly enables it).
+ *
+ *  * An initial set of seals is applied to the memfd, if specified in
+ *    @seals. Note that this is not allowed if sealing was not enabled.
+ *
+ * Return: New memfd file-descriptor on success, -1 on failure.
+ */
+int misc_memfd(const char *name, unsigned int uflags, unsigned int useals) {
+        _c_cleanup_(c_closep) int fd = -1;
+        unsigned int flags = uflags;
+        unsigned int seals = useals;
+        struct stat st;
+        int r;
+
+        /*
+         * You cannot set any seals if you disable sealing (apart from
+         * F_SEAL_SEAL, which is what the kernel sets to disable sealing).
+         */
+        if (!(flags & MISC_MFD_ALLOW_SEALING)) {
+                if (seals & ~MISC_F_SEAL_SEAL)
+                        return error_origin(-ENOTRECOVERABLE);
+
+                /* Already set by the kernel if sealing is disabled. */
+                seals &= ~MISC_F_SEAL_SEAL;
+        }
+
+        /*
+         * Newer kernels require you to either specify `MFD_EXEC` or
+         * `MFD_NOEXEC_SEAL` or it will warn loudly. Hence we enforce this in
+         * our codebase. For older kernels, we strip these flags automatically.
+         */
+        if (!(flags & (MISC_MFD_EXEC | MISC_MFD_NOEXEC_SEAL)))
+                return error_origin(-ENOTRECOVERABLE);
+
+        /*
+         * Create the memfd. If the flags are not supported, strip the EXEC
+         * flags and try again. We can emulate them, and older kernels refuse
+         * them.
+         */
+        fd = syscall_memfd_create(name, flags);
+        if (fd < 0 && errno == EINVAL) {
+                flags &= ~(MISC_MFD_EXEC | MISC_MFD_NOEXEC_SEAL);
+                fd = syscall_memfd_create(name, flags);
+        }
+        if (fd < 0)
+                return error_origin(-errno);
+
+        /*
+         * If the kernel did not support `MFD_NOEXEC_SEAL`, but we want it, we
+         * strip the executable bits ourselves. They are set by default.
+         */
+        if ((uflags & MISC_MFD_NOEXEC_SEAL) && !(flags & MISC_MFD_NOEXEC_SEAL)) {
+                r = fstat(fd, &st);
+                if (r < 0)
+                        return error_origin(-errno);
+
+                r = fchmod(fd, st.st_mode & 07666);
+                if (r < 0)
+                        return error_origin(-errno);
+        }
+
+        /*
+         * If we ended up passing `MFG_NOEXEC_SEAL` to the kernel, the kernel
+         * will implicitly enable sealing. This is very unfortunate, so we
+         * revert this if the caller did not explicitly allow it. To disable
+         * sealing, simply set `F_SEAL_SEAL`, which is also what the kernel
+         * does.
+         */
+        if ((flags & MISC_MFD_NOEXEC_SEAL) && !(flags & MISC_MFD_ALLOW_SEALING))
+                seals |= MISC_F_SEAL_SEAL;
+
+        /*
+         * If the user wants initial seals, lets set them. Sadly,
+         * memfd_create(2) does not support initial seals, so we have to call
+         * into the kernel again.
+         */
+        if (seals) {
+                r = misc_memfd_add_seals(fd, seals);
+                if (r)
+                        return error_fold(r);
+        }
+
+        r = fd;
+        fd = -1;
+        return r;
+}
+
+/**
+ * misc_memfd_add_seals() - add seals to a memfd
+ * @fd:         memfd to operate on
+ * @seals:      seals to set
+ *
+ * Add the specified seals to the set of seals on the memfd. If the FD does not
+ * refer to a memfd (or other file that supports sealing), an error will be
+ * returned. If the memfd does not support sealing, or if `F_SEAL_SEAL` was
+ * already set, `-EPERM` is returned.
+ *
+ * Write access is needed to add seals to a memfd, or `-EPERM` will be
+ * returned.
+ *
+ * Adding seals that are already set is a no-op (unless `F_SEAL_SEAL` is set,
+ * in which case this operation always fails).
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int misc_memfd_add_seals(int fd, unsigned int seals) {
+        int r;
+
+        r = fcntl(fd, MISC_F_ADD_SEALS, seals);
+        if (r < 0)
+                return error_origin(-errno);
+
+        return 0;
+}
+
+/**
+ * misc_memfd_get_seals() - query seals of a memfd
+ * @fd:         memfd to operate on
+ *
+ * Query the seals of the memfd. If the FD does not refer to a memfd (or other
+ * file that supports sealing), an error will be returned.
+ *
+ * Return: Seal mask of the memfd is returned, negative error code on failure.
+ */
+int misc_memfd_get_seals(int fd) {
+        int seals;
+
+        seals = fcntl(fd, MISC_F_GET_SEALS);
+        if (seals < 0)
+                return error_origin(-errno);
+
+        return seals;
+}
 
 /**
  * util_umul64_saturating() - saturating multiplication

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -7,5 +7,22 @@
 #include <c-stdaux.h>
 #include <stdlib.h>
 
+#define MISC_MFD_CLOEXEC                0x0001U
+#define MISC_MFD_ALLOW_SEALING          0x0002U
+#define MISC_MFD_HUGETLB                0x0004U
+#define MISC_MFD_NOEXEC_SEAL            0x0008U
+#define MISC_MFD_EXEC                   0x0010U
+
+#define MISC_F_SEAL_SEAL                0x0001U
+#define MISC_F_SEAL_SHRINK              0x0002U
+#define MISC_F_SEAL_GROW                0x0004U
+#define MISC_F_SEAL_WRITE               0x0008U
+#define MISC_F_SEAL_FUTURE_WRITE        0x0010U
+#define MISC_F_SEAL_EXEC                0x0020U
+
+int misc_memfd(const char *name, unsigned int uflags, unsigned int useals);
+int misc_memfd_add_seals(int fd, unsigned int seals);
+int misc_memfd_get_seals(int fd);
+
 uint64_t util_umul64_saturating(uint64_t a, uint64_t b);
 int util_drop_permissions(uint32_t uid, uint32_t gid);

--- a/src/util/test-misc.c
+++ b/src/util/test-misc.c
@@ -5,7 +5,116 @@
 #undef NDEBUG
 #include <c-stdaux.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include "util/misc.h"
+
+/*
+ * Check for which memfd-seals are supported by the running kernel and return
+ * them as mask to the caller. This allows running tests on older kernels,
+ * that possibly do not support the newer seals.
+ */
+static unsigned int memfd_seals(void) {
+        unsigned int seal_mask;
+        int fd;
+
+        seal_mask = MISC_F_SEAL_SEAL | MISC_F_SEAL_SHRINK |
+                    MISC_F_SEAL_GROW | MISC_F_SEAL_WRITE;
+
+        fd = misc_memfd(
+                "test",
+                MISC_MFD_ALLOW_SEALING | MISC_MFD_NOEXEC_SEAL,
+                MISC_F_SEAL_FUTURE_WRITE
+        );
+        if (fd >= 0) {
+                seal_mask |= MISC_F_SEAL_FUTURE_WRITE;
+                c_close(fd);
+        }
+
+        fd = misc_memfd(
+                "test",
+                MISC_MFD_ALLOW_SEALING | MISC_MFD_NOEXEC_SEAL,
+                MISC_F_SEAL_EXEC
+        );
+        if (fd >= 0) {
+                seal_mask |= MISC_F_SEAL_EXEC;
+                c_close(fd);
+        }
+
+        return seal_mask;
+}
+
+static void test_memfd(void) {
+        static const struct {
+                unsigned int in_flags;
+                unsigned int in_seals;
+                int out_error;
+                unsigned int out_seals;
+                unsigned int out_fmode;
+        } v[] = {
+                {
+                        .out_error = -ENOTRECOVERABLE,
+                },
+                {
+                        .in_flags = MISC_MFD_EXEC,
+                        .in_seals = MISC_F_SEAL_WRITE,
+                        .out_error = -ENOTRECOVERABLE,
+                },
+                {
+                        .in_flags = MISC_MFD_EXEC,
+                        .out_seals = MISC_F_SEAL_SEAL,
+                        .out_fmode = 0777,
+                },
+                {
+                        .in_flags = MISC_MFD_EXEC,
+                        .in_seals = MISC_F_SEAL_SEAL,
+                        .out_seals = MISC_F_SEAL_SEAL,
+                        .out_fmode = 0777,
+                },
+                {
+                        .in_flags = MISC_MFD_NOEXEC_SEAL,
+                        .out_seals = MISC_F_SEAL_SEAL | MISC_F_SEAL_EXEC,
+                        .out_fmode = 0666,
+                },
+                {
+                        .in_flags = MISC_MFD_ALLOW_SEALING | MISC_MFD_NOEXEC_SEAL,
+                        .out_seals = MISC_F_SEAL_EXEC,
+                        .out_fmode = 0666,
+                },
+                {
+                        .in_flags = MISC_MFD_ALLOW_SEALING | MISC_MFD_NOEXEC_SEAL,
+                        .in_seals = MISC_F_SEAL_WRITE,
+                        .out_seals = MISC_F_SEAL_WRITE | MISC_F_SEAL_EXEC,
+                        .out_fmode = 0666,
+                },
+        };
+        unsigned int seal_mask;
+        struct stat st;
+        size_t i;
+        int r, fd, seals;
+
+        seal_mask = memfd_seals();
+
+        for (i = 0; i < C_ARRAY_SIZE(v); ++i) {
+                c_assert(!(v[i].in_seals & ~seal_mask));
+
+                fd = misc_memfd("test", v[i].in_flags, v[i].in_seals);
+                if (fd < 0) {
+                        c_assert(fd == v[i].out_error);
+                        continue;
+                }
+                c_assert(!v[i].out_error);
+
+                seals = misc_memfd_get_seals(fd);
+                c_assert(seals >= 0);
+                c_assert((seals & seal_mask) == (v[i].out_seals & seal_mask));
+
+                r = fstat(fd, &st);
+                c_assert(r >= 0);
+                c_assert((st.st_mode & 07777) == v[i].out_fmode);
+
+                c_close(fd);
+        }
+}
 
 static void test_umul_saturating(void) {
         static const struct {
@@ -36,6 +145,7 @@ static void test_umul_saturating(void) {
 }
 
 int main(int argc, char **argv) {
+        test_memfd();
         test_umul_saturating();
         return 0;
 }

--- a/src/util/test-proc.c
+++ b/src/util/test-proc.c
@@ -5,6 +5,7 @@
 #undef NDEBUG
 #include <c-stdaux.h>
 #include <stdlib.h>
+#include "util/misc.h"
 #include "util/proc.h"
 #include "util/string.h"
 #include "util/syscall.h"
@@ -60,7 +61,7 @@ static void test_read(void) {
         ssize_t l;
         int r;
 
-        fd = syscall_memfd_create("test-proc", 0x1);
+        fd = misc_memfd("test-proc", MISC_MFD_CLOEXEC | MISC_MFD_NOEXEC_SEAL, 0);
         c_assert(fd >= 0);
 
         for (i = 0; i < 1024; i += strlen(str)) {


### PR DESCRIPTION
Provide proper abstractions for memfd operations. This is especially necessary with the new `MFD_EXEC` and `MFD_NOEXEC_SEAL` features of the kernel, which requires all memfd users to update the code to use one of the new flags.

Unfortunately, they decided against providing `MFD_NOEXEC`, but instead just provide `MFD_NOEXEC_SEAL`, which is a combination of `MFD_ALLOW_SEALING`, `MFD_NOEXEC`, and `F_SEAL_EXEC`. This is really awkward to use in helpers, but I think I got something that works well enough.

Reported in #322.