### PR TITLE
launcher: start unit immediately as unprivileged user

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,9 @@ use_audit = get_option('audit')
 if use_audit
         dep_libaudit = dependency('audit', version: '>=3.0')
         dep_libcapng = dependency('libcap-ng', version: '>=0.6')
+        conf.set('ambientcaps', 'AmbientCapabilities=CAP_AUDIT_WRITE')
+else
+        conf.set('ambientcaps', '')
 endif
 
 #

--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -1086,6 +1086,14 @@ static int launcher_parse_config(Launcher *launcher, ConfigRoot **rootp, NSSCach
         /* Remember if our at_console compat logic is needed */
         launcher->at_console = at_console;
 
+        /*
+         * If we are not running as root but systemd launched us as a non-privileged user, enforce that
+         * the configuration is coherent with the unit setting and return an error otherwise, to avoid
+         * unexpected results.
+         */
+        if (launcher->uid != (uint32_t)-1 && geteuid() != 0 && geteuid() != launcher->uid)
+                return LAUNCHER_E_INVALID_CONFIG;
+
         return 0;
 }
 

--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -17,6 +17,9 @@ PrivateTmp=true
 PrivateDevices=true
 ExecStart=@bindir@/dbus-broker-launch --scope system --audit
 ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
+User=messagebus
+Group=messagebus
+@ambientcaps@
 
 [Install]
 Alias=dbus.service

--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -34,14 +34,15 @@ int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
         int r;
 
         /*
-         * This is modeled exactly after the behavior of dbus-daemon(1). We
-         * have to be compatibile and fail in the exact same situations. This
-         * means, only try to retain CAP_AUDIT_WRITE if we are running as root
-         * and own it. In all other cases, simply drop privileges to the
-         * requested IDs.
+         * This is similar but not indentical to the behavior of dbus-daemon(1).
+         * If we have CAP_AUDIT_WRITE, as root or non-root, then we retain it.
+         * In other cases simply drop privileges to the requested IDs.
          */
 
         if (geteuid() != 0) {
+                if (capng_have_capability(CAPNG_EFFECTIVE, CAP_AUDIT_WRITE))
+                        return 0; /* Nothing to do */
+
                 /*
                  * For compatibility to dbus-daemon, this must be
                  * non-fatal.

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -33,6 +33,9 @@ uint64_t util_umul64_saturating(uint64_t a, uint64_t b) {
 int util_drop_permissions(uint32_t uid, uint32_t gid) {
         int r;
 
+        if (geteuid() == uid && getuid() == uid && getegid() == gid && getgid() == gid)
+                return 0; /* Nothing to do */
+
         /* for compatibility to dbus-daemon, this must be non-fatal */
         setgroups(0, NULL);
 


### PR DESCRIPTION
It is better to never have privileges rather than start with them and remove them later, as the attack surface is reduced, and there are fewer things to do before being 'ready'. Nowadays systemd can run the service as the appropriate user/group out of the box.

When starting as root files in /proc/self/fdinfo/ will be owned as root and set to 400, so we cannot read them. Nowadays it is not necessary to start as root when running under systemd, so just add User/Group with the configured user to the system unit. Add a meson option to let users configure the user, and default to the same as dbus-daemon's default, 'messagebus'.

If libaudit support is enabled, add AmbientCapabilities=CAP_AUDIT_WRITE so that we can still write to the audit log.

Same change for dbus-daemon: https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/399