### PR TITLE
A couple of test tweaks

### DIFF
--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -75,12 +75,28 @@ test('Signals and Matches', test_matches)
 if use_reference_test
         dbus_bin = dep_dbus.get_variable(pkgconfig: 'bindir') + '/dbus-daemon'
 
-        benchmark('dbus-daemon(1): Connection', bench_connect, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ], timeout: 60)
-        benchmark('dbus-daemon(1): Message passing', bench_message, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ], timeout: 120)
+        benchmark('Connection', bench_connect,
+                  suite: 'dbus-daemon(1)',
+                  env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ],
+                  timeout: 60)
+        benchmark('Message passing', bench_message,
+                  suite: 'dbus-daemon(1)',
+                  env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ],
+                  timeout: 120)
 
-        test('dbus-daemon(1): Broker API', test_broker, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('dbus-daemon(1): Driver API', test_driver, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('dbus-daemon(1): FD Stream Constraints', test_fdstream, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('dbus-daemon(1): Client Lifetime', test_lifetime, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('dbus-daemon(1): Signals and Matches', test_matches, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('Broker API', test_broker,
+              suite: 'dbus-daemon(1)',
+              env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('Driver API', test_driver,
+             suite: 'dbus-daemon(1)',
+             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('FD Stream Constraints', test_fdstream,
+             suite: 'dbus-daemon(1)',
+             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('Client Lifetime', test_lifetime,
+             suite: 'dbus-daemon(1)',
+             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        test('Signals and Matches', test_matches,
+             suite: 'dbus-daemon(1)',
+             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
 endif

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -73,7 +73,7 @@ test_matches = executable('test-matches', ['test-matches.c'], dependencies: [ de
 test('Signals and Matches', test_matches)
 
 if use_reference_test
-        dbus_bin = dep_dbus.get_pkgconfig_variable('bindir') + '/dbus-daemon'
+        dbus_bin = dep_dbus.get_variable(pkgconfig: 'bindir') + '/dbus-daemon'
 
         benchmark('dbus-daemon(1): Connection', bench_connect, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ], timeout: 60)
         benchmark('dbus-daemon(1): Message passing', bench_message, env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ], timeout: 120)


### PR DESCRIPTION
This gets rid of two meson deprecation warnings and also makes most (\*) of the reference tests work with newer dbus-daemon (F39 and Rawhide), that started using path-based sockets instead of abstract ones.

(\*) 

```
$ meson test -C build --suite 'dbus-daemon(1)' --print-errorlogs                                                                                                                            
ninja: Entering directory `/home/fsumsal/repos/dbus-broker/build'                                                                                                                           
[7/7] Linking target test/dbus/test-fdstream                                                                                                                                                
1/5 dbus-broker:dbus-daemon(1) / FD Stream Constraints        SKIP            0.01s   exit status 77
2/5 dbus-broker:dbus-daemon(1) / Broker API                   OK              0.01s                                                                                                         
3/5 dbus-broker:dbus-daemon(1) / Client Lifetime              OK              0.02s           
4/5 dbus-broker:dbus-daemon(1) / Signals and Matches          OK              0.03s                                                                                                         
dbus-broker:dbus-daemon(1) / Driver API time out (After 30 seconds)                                                                                                                         
5/5 dbus-broker:dbus-daemon(1) / Driver API                   TIMEOUT        30.01s   killed by signal 6 SIGABRT      
```

The last test fails in this test case:
https://github.com/bus1/dbus-broker/blob/db8f3cacd5b72d8e32d627cbe06d09546d1ecf65/test/dbus/test-driver.c#L1742-L1754

because there's no `UnixGroupIDs` sent back. I can reproduce this on latest Fedora Rawhide if I switch from dbus-broker to dbus-daemon and issue the D-Bus call directly:
```
# rpm -q dbus-daemon
dbus-daemon-1.14.10-3.fc40.x86_64
# busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus GetConnectionCredentials s org.freedesktop.DBus
a{sv} 2 "ProcessID" u 582 "UnixUserID" u 81
```

Doing the same with dbus-broker seems to return "expected" results:
```
# rpm -q dbus-broker
dbus-broker-35-4.fc40.x86_64
# busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus GetConnectionCredentials s org.freedesktop.DBus
a{sv} 5 "UnixUserID" u 0 "ProcessID" u 578 "UnixGroupIDs" au 1 0 "LinuxSecurityLabel" ay 48 115 121 115 116 101 109 95 117 58 115 121 115 116 101 109 95 114 58 115 121 115 116 101 109 95 100 98 117 115 100 95 116 58 115 48 45 115 48 58 99 48 46 99 49 48 50 51 0 "ProcessFD" h 4
```

I'm not sure if this is a bug or not (or at least I couldn't find anything obvious in dbus-daemon's [release notes](https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/NEWS), apart from maybe [this bugfix](https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/NEWS#L90-92) that's in v1.15.8).
