### PR TITLE
test: allow installing built test executables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,12 @@ if use_docs
 endif
 
 #
+# Config: install-tests
+#
+install_tests = get_option('install-tests')
+test_install_dir = get_option('prefix') / 'lib/dbus-broker/tests'
+
+#
 # Config: launcher
 #
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('apparmor', type: 'boolean', value: false, description: 'AppArmor support')
 option('audit', type: 'boolean', value: false, description: 'Audit support')
 option('docs', type: 'boolean', value: false, description: 'Build documentation')
+option('install-tests', type: 'boolean', value: false, description: 'Install test executables')
 option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
 option('linux-4-17', type: 'boolean', value: false, description: 'Require linux-4.17 at runtime and make use of its features')
 option('reference-test', type: 'boolean', value: false, description: 'Run test suite against reference implementation')

--- a/src/meson.build
+++ b/src/meson.build
@@ -173,75 +173,195 @@ endif
 # target: test-*
 #
 
-test_address = executable('test-address', ['dbus/test-address.c'], dependencies: dep_bus)
+test_unit_install_kwargs = {
+        'install': install_tests,
+        'install_dir': test_install_dir / 'unit',
+}
+
+test_address = executable(
+        'test-address',
+        sources: ['dbus/test-address.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Address Handling', test_address)
 
-test_apparmor = executable('test-apparmor', ['util/test-apparmor.c'], dependencies: dep_bus)
+test_apparmor = executable(
+        'test-apparmor',
+        sources: ['util/test-apparmor.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('AppArmor Handling', test_apparmor)
 
 if use_launcher
-        test_config = executable('test-config', ['launch/test-config.c'], dependencies: dep_bus)
+        test_config = executable(
+                'test-config',
+                sources: ['launch/test-config.c'],
+                dependencies: dep_bus,
+                kwargs: test_unit_install_kwargs
+        )
         test('Configuration Parser', test_config)
 endif
 
-test_dirwatch = executable('test-dirwatch', ['util/test-dirwatch.c'], dependencies: dep_bus)
+test_dirwatch = executable(
+        'test-dirwatch',
+        sources: ['util/test-dirwatch.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Directory Watch', test_dirwatch)
 
-test_dispatch = executable('test-dispatch', ['util/test-dispatch.c'], dependencies: dep_bus)
+test_dispatch = executable(
+        'test-dispatch',
+        sources: ['util/test-dispatch.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Event Dispatcher', test_dispatch)
 
-test_error = executable('test-error', ['util/test-error.c'], dependencies: dep_bus)
+test_error = executable(
+        'test-error',
+        sources: ['util/test-error.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Error Handling', test_error)
 
-test_fdlist = executable('test-fdlist', ['util/test-fdlist.c'], dependencies: dep_bus)
+test_fdlist = executable(
+        'test-fdlist',
+        sources: ['util/test-fdlist.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Utility File-Desciptor Lists', test_fdlist)
 
-test_fs = executable('test-fs', ['util/test-fs.c'], dependencies: dep_bus)
+test_fs = executable(
+        'test-fs',
+        sources: ['util/test-fs.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('File System Helpers', test_fs)
 
-test_match = executable('test-match', ['bus/test-match.c'], dependencies: dep_bus)
+test_match = executable(
+        'test-match',
+        sources: ['bus/test-match.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus Match Handling', test_match)
 
-test_message = executable('test-message', ['dbus/test-message.c'], dependencies: dep_bus)
+test_message = executable(
+        'test-message',
+        sources: ['dbus/test-message.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus Message Abstraction', test_message)
 
-test_misc = executable('test-misc', ['util/test-misc.c'], dependencies: dep_bus)
+test_misc = executable(
+        'test-misc',
+        sources: ['util/test-misc.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Miscellaneous Helpers', test_misc)
 
-test_name = executable('test-name', ['bus/test-name.c'], dependencies: dep_bus)
+test_name = executable(
+        'test-name',
+        sources: ['bus/test-name.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Name Registry', test_name)
 
 if use_launcher
-        test_nss_cache = executable('test-nss-cache', ['launch/test-nss-cache.c'], dependencies: dep_bus)
+        test_nss_cache = executable(
+                'test-nss-cache',
+                sources: ['launch/test-nss-cache.c'],
+                dependencies: dep_bus,
+                kwargs: test_unit_install_kwargs
+        )
         test('NSS Cache', test_nss_cache)
 endif
 
-test_peersec = executable('test-peersec', ['util/test-peersec.c'], dependencies: dep_bus)
+test_peersec = executable(
+        'test-peersec',
+        sources: ['util/test-peersec.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('SO_PEERSEC Queries', test_peersec)
 
-test_proc = executable('test-proc', ['util/test-proc.c'], dependencies: dep_bus)
+test_proc = executable(
+        'test-proc',
+        sources: ['util/test-proc.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Proc Utilities', test_proc)
 
-test_queue = executable('test-queue', ['dbus/test-queue.c'], dependencies: dep_bus)
+test_queue = executable(
+        'test-queue',
+        sources: ['dbus/test-queue.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus I/O Queues', test_queue)
 
-test_reply = executable('test-reply', ['bus/test-reply.c'], dependencies: dep_bus)
+test_reply = executable(
+        'test-reply',
+        sources: ['bus/test-reply.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Reply Tracking', test_reply)
 
-test_sasl = executable('test-sasl', ['dbus/test-sasl.c'], dependencies: dep_bus)
+test_sasl = executable(
+        'test-sasl',
+        sources: ['dbus/test-sasl.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus SASL Parser', test_sasl)
 
-test_socket = executable('test-socket', ['dbus/test-socket.c'], dependencies: dep_bus)
+test_socket = executable(
+        'test-socket',
+        sources: ['dbus/test-socket.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus Socket Abstraction', test_socket)
 
-test_sockopt = executable('test-sockopt', ['util/test-sockopt.c'], dependencies: dep_bus)
+test_sockopt = executable(
+        'test-sockopt',
+        sources: ['util/test-sockopt.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('D-Bus Socket Options', test_sockopt)
 
-test_stitching = executable('test-stitching', ['dbus/test-stitching.c'], dependencies: dep_bus)
+test_stitching = executable(
+        'test-stitching',
+        sources: ['dbus/test-stitching.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Message Sender Stitching', test_stitching)
 
-test_systemd = executable('test-systemd', ['util/test-systemd.c'], dependencies: dep_bus)
+test_systemd = executable(
+        'test-systemd',
+        sources: ['util/test-systemd.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('Systemd Utilities', test_systemd)
 
-test_user = executable('test-user', ['util/test-user.c'], dependencies: dep_bus)
+test_user = executable(
+        'test-user',
+        sources: ['util/test-user.c'],
+        dependencies: dep_bus,
+        kwargs: test_unit_install_kwargs
+)
 test('User Accounting', test_user)

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -41,62 +41,44 @@ dep_test = declare_dependency(
 # target: tool-*
 #
 
-tool_flood = executable('tool-flood', ['tool-flood.c'], dependencies: [ dep_test ])
+tool_flood = executable('tool-flood', ['tool-flood.c'], dependencies: [dep_test])
 
 #
 # target: bench-*
 #
 
-bench_connect = executable('bench-connect', ['bench-connect.c'], dependencies: [ dep_test ])
-benchmark('Connection', bench_connect)
-
-bench_message = executable('bench-message', ['bench-message.c'], dependencies: [ dep_test ])
-benchmark('Message passing', bench_message)
+bench_connect = executable('bench-connect', ['bench-connect.c'], dependencies: [dep_test])
+bench_message = executable('bench-message', ['bench-message.c'], dependencies: [dep_test])
 
 #
 # target: test-*
 #
 
-test_broker = executable('test-broker', ['test-broker.c'], dependencies: [ dep_test ])
-test('Broker API', test_broker)
+test_broker = executable('test-broker', ['test-broker.c'], dependencies: [dep_test])
+test_driver = executable('test-driver', ['test-driver.c'], dependencies: [dep_test])
+test_fdstream = executable('test-fdstream', ['test-fdstream.c'], dependencies: [dep_test])
+test_lifetime = executable('test-lifetime', ['test-lifetime.c'], dependencies: [dep_test])
+test_matches = executable('test-matches', ['test-matches.c'], dependencies: [dep_test])
 
-test_driver = executable('test-driver', ['test-driver.c'], dependencies: [ dep_test ])
-test('Driver API', test_driver)
 
-test_fdstream = executable('test-fdstream', ['test-fdstream.c'], dependencies: [ dep_test ])
-test('FD Stream Constraints', test_fdstream)
-
-test_lifetime = executable('test-lifetime', ['test-lifetime.c'], dependencies: [ dep_test ])
-test('Client Lifetime', test_lifetime)
-
-test_matches = executable('test-matches', ['test-matches.c'], dependencies: [ dep_test ])
-test('Signals and Matches', test_matches)
+suites = [
+        { 'suite': 'dbus-broker(1)', 'env': ['DBUS_BROKER_TEST_BROKER=' + exe_dbus_broker.full_path()]},
+]
 
 if use_reference_test
-        dbus_bin = dep_dbus.get_variable(pkgconfig: 'bindir') + '/dbus-daemon'
-
-        benchmark('Connection', bench_connect,
-                  suite: 'dbus-daemon(1)',
-                  env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ],
-                  timeout: 60)
-        benchmark('Message passing', bench_message,
-                  suite: 'dbus-daemon(1)',
-                  env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ],
-                  timeout: 120)
-
-        test('Broker API', test_broker,
-              suite: 'dbus-daemon(1)',
-              env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('Driver API', test_driver,
-             suite: 'dbus-daemon(1)',
-             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('FD Stream Constraints', test_fdstream,
-             suite: 'dbus-daemon(1)',
-             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('Client Lifetime', test_lifetime,
-             suite: 'dbus-daemon(1)',
-             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
-        test('Signals and Matches', test_matches,
-             suite: 'dbus-daemon(1)',
-             env: [ 'DBUS_BROKER_TEST_DAEMON=' + dbus_bin ])
+        dbus_daemon_bin = dep_dbus.get_variable(pkgconfig: 'bindir') + '/dbus-daemon'
+        suites += [
+                { 'suite': 'dbus-daemon(1)', 'env': ['DBUS_BROKER_TEST_DAEMON=' + dbus_daemon_bin]},
+        ]
 endif
+
+foreach suite : suites
+        benchmark('Connection', bench_connect, timeout: 60, kwargs: suite)
+        benchmark('Message passing', bench_message, timeout: 120, kwargs: suite)
+
+        test('Broker API', test_broker, kwargs: suite)
+        test('Driver API', test_driver, kwargs: suite)
+        test('FD Stream Constraints', test_fdstream, kwargs: suite)
+        test('Client Lifetime', test_lifetime, kwargs: suite)
+        test('Signals and Matches', test_matches, kwargs: suite)
+endforeach

--- a/test/dbus/meson.build
+++ b/test/dbus/meson.build
@@ -37,6 +37,11 @@ dep_test = declare_dependency(
         version: meson.project_version(),
 )
 
+test_dbus_install_kwargs = {
+        'install': install_tests,
+        'install_dir': test_install_dir / 'dbus',
+}
+
 #
 # target: tool-*
 #
@@ -47,19 +52,53 @@ tool_flood = executable('tool-flood', ['tool-flood.c'], dependencies: [dep_test]
 # target: bench-*
 #
 
-bench_connect = executable('bench-connect', ['bench-connect.c'], dependencies: [dep_test])
-bench_message = executable('bench-message', ['bench-message.c'], dependencies: [dep_test])
+bench_connect = executable(
+        'bench-connect',
+        sources: ['bench-connect.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
+bench_message = executable(
+        'bench-message',
+        sources: ['bench-message.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
 
 #
 # target: test-*
 #
 
-test_broker = executable('test-broker', ['test-broker.c'], dependencies: [dep_test])
-test_driver = executable('test-driver', ['test-driver.c'], dependencies: [dep_test])
-test_fdstream = executable('test-fdstream', ['test-fdstream.c'], dependencies: [dep_test])
-test_lifetime = executable('test-lifetime', ['test-lifetime.c'], dependencies: [dep_test])
-test_matches = executable('test-matches', ['test-matches.c'], dependencies: [dep_test])
-
+test_broker = executable(
+        'test-broker',
+        sources: ['test-broker.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
+test_driver = executable(
+        'test-driver',
+        sources: ['test-driver.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
+test_fdstream = executable(
+        'test-fdstream',
+        sources: ['test-fdstream.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
+test_lifetime = executable(
+        'test-lifetime',
+        sources: ['test-lifetime.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
+test_matches = executable(
+        'test-matches',
+        sources: ['test-matches.c'],
+        dependencies: [dep_test],
+        kwargs: test_dbus_install_kwargs
+)
 
 suites = [
         { 'suite': 'dbus-broker(1)', 'env': ['DBUS_BROKER_TEST_BROKER=' + exe_dbus_broker.full_path()]},

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -183,6 +183,7 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
         _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message = NULL;
         _c_cleanup_(c_freep) char *fdstr = NULL;
+        const char *bin;
         int r, pair[2];
         pid_t pid;
 
@@ -203,8 +204,10 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
                 r = asprintf(&fdstr, "%d", pair[1]);
                 c_assert(r >= 0);
 
-                r = execl("./src/dbus-broker",
-                          "./src/dbus-broker",
+                bin = getenv("DBUS_BROKER_TEST_BROKER") ?: "/usr/bin/dbus-broker";
+                fprintf(stderr, "Using dbus-broker binary %s\n", bin);
+                r = execl(bin,
+                          bin,
                           "--controller", fdstr,
                           "--machine-id", "0123456789abcdef0123456789abcdef",
                           "--max-matches", "1000000",
@@ -319,6 +322,7 @@ void util_fork_daemon(sd_event *event, int pipe_fd, pid_t *pidp) {
 
                 /* exec dbus-daemon */
                 bin = getenv("DBUS_BROKER_TEST_DAEMON") ?: "/usr/bin/dbus-daemon";
+                fprintf(stderr, "Using dbus-daemon binary %s\n", bin);
                 r = execl(bin,
                           bin,
                           path,


### PR DESCRIPTION
This PR introduces two changes: making the reference tests work without a build dir and, subsequently, allowing both reference and unit tests to be installed along with dbus-broker itself, so they can be later used to verify if the installed dbus-broker behaves as expected.

The first change unifies an already existing behavior, where the path to a dbus-daemon binary can be tweaked via an environment variable - the name of the variable was changed to `TEST_DBUS_DAEMON`, and a new env variable - `TEST_DBUS_BROKER` - was introduced that does the same thing, but for the dbus-broker binary (instead of hardcoding the path directly). Both paths now default to `/usr/bin/{dbus-daemon,dbus-broker}`; when running the tests using meson the path for dbus-broker is overridden to point to the just built binary. This should make the tests behave correctly both when run standalone and during development.

The second change makes both unit and reference tests installable (if requested) under `<prefix>/share/dbus-broker`. The idea here is to follow-up this change with a change in the dbus-broker spec file to split the tests into a separate RPM (like dbus-broker-tests), which can be then easily consumed by the CI infra introduced in #348. The `<prefix>/share/dbus-broker` path is more like a proposal than a set thing, as I have no preference here. I went through several test packages in Fedora (like `systemd-tests`, `dbus-tests`, `firewalld-test`, etc.), and the `<prefix>/share/...` path seems to be the most used one.

Also a note: the changes make a heavy use of the meson's "kwargs" feature, which reduces code duplication quite a lot. This was introduced in meson 0.49.0, but since we already depend on at least 0.60.0, we should be, hopefully, fine.