### PR TITLE
bus/driver: duplicate FDs for queued messages

### DIFF
--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -524,7 +524,7 @@ static int driver_send_reply_with_fds(Peer *peer, CDVar *var, uint32_t serial, i
         data = NULL;
 
         if (n_fds > 0) {
-                r = fdlist_new_with_fds(&message->fds, fds, n_fds);
+                r = fdlist_new_dup_fds(&message->fds, fds, n_fds);
                 if (r)
                         return error_fold(r);
         }

--- a/src/util/fdlist.h
+++ b/src/util/fdlist.h
@@ -17,6 +17,7 @@ struct FDList {
 
 int fdlist_new_with_fds(FDList **listp, const int *fds, size_t n_fds);
 int fdlist_new_consume_fds(FDList **listp, const int *fds, size_t n_fds);
+int fdlist_new_dup_fds(FDList **listp, const int *fds, size_t n_fds);
 FDList *fdlist_free(FDList *list);
 void fdlist_truncate(FDList *list, size_t n_fds);
 int fdlist_steal(FDList *list, size_t index);


### PR DESCRIPTION
Duplicate FDs for queued messages to ensure they stay around until a message is queued. This fixes a bug where we might try to send messages referencing closed file-descriptors.