### PR TITLE
dbus/socket: protect against no-op arithmetic on NULL pointers

### DIFF
--- a/src/dbus/socket.c
+++ b/src/dbus/socket.c
@@ -173,9 +173,13 @@ static bool socket_buffer_consume(SocketBuffer *buffer, size_t n) {
 
         for ( ; !socket_buffer_is_consumed(buffer); ++buffer->writer) {
                 t = c_min(buffer->writer->iov_len, n);
-                buffer->writer->iov_len -= t;
-                buffer->writer->iov_base += t;
-                n -= t;
+                // IOVs can be empty/NULL. Ensure we do not calculate
+                // `NULL + 0`, as this is, unfortunately, UB.
+                if (t) {
+                        buffer->writer->iov_len -= t;
+                        buffer->writer->iov_base += t;
+                        n -= t;
+                }
                 if (buffer->writer->iov_len)
                         break;
         }


### PR DESCRIPTION
The socket layer assumes that computing `NULL + 0` produces `NULL`. Unfortunately, this is UB. Protect against this pointer arithmetic and ensure we correctly skip empty IOVs when consuming socket buffers.

Reported in #365.