### PR TITLE
launcher: allow searching for system-services in /etc/ and /run/

### DIFF
--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -925,6 +925,8 @@ static int launcher_load_standard_session_services(Launcher *launcher, NSSCache 
 
 static int launcher_load_standard_system_services(Launcher *launcher, NSSCache *nss_cache) {
         static const char *default_data_dirs[] = {
+                "/etc",
+                "/run",
                 "/usr/local/share",
                 "/usr/share",
                 "/lib",


### PR DESCRIPTION
This is useful when an asset manager wants to install a system service while /usr/ is read-only (e.g.: local system services running on a different namespaced image)

spec and dbus-daemon corresponding change: https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/467