### PR TITLE
ci: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -46,7 +46,7 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
       if: failure() && steps.build.outcome == 'success'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.sanitizer }}-${{ matrix.architecture }}-artifacts
         path: ./out/artifacts


### PR DESCRIPTION
As v3 is deprecated and is going away at the end of January.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/