### PR TITLE
Add notify-reload support to dbus-broker

### DIFF
--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -29,6 +29,7 @@
 #include "util/fs.h"
 #include "util/log.h"
 #include "util/misc.h"
+#include "util/nsec.h"
 #include "util/string.h"
 
 /*
@@ -1167,7 +1168,10 @@ static int launcher_reload_config(Launcher *launcher) {
         Service *service;
         int r, res;
 
-        r = sd_notify(false, "RELOADING=1");
+        r = sd_notifyf(/* unset_environment = */ false,
+                       "RELOADING=1\n"
+                       "MONOTONIC_USEC=%" NSEC_PRI,
+                       nsec_to_usec(nsec_now(CLOCK_MONOTONIC)));
         if (r < 0)
                 return error_origin(r);
 

--- a/src/units/system/dbus-broker.service.in
+++ b/src/units/system/dbus-broker.service.in
@@ -8,7 +8,7 @@ Requires=dbus.socket
 Conflicts=shutdown.target
 
 [Service]
-Type=notify
+Type=notify-reload
 Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
@@ -16,7 +16,6 @@ ProtectSystem=full
 PrivateTmp=true
 PrivateDevices=true
 ExecStart=@bindir@/dbus-broker-launch --scope system --audit
-ExecReload=@bindir@/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
 
 [Install]
 Alias=dbus.service

--- a/src/units/user/dbus-broker.service.in
+++ b/src/units/user/dbus-broker.service.in
@@ -8,10 +8,9 @@ Requires=dbus.socket
 Conflicts=shutdown.target
 
 [Service]
-Type=notify
+Type=notify-reload
 Sockets=dbus.socket
 ExecStart=@bindir@/dbus-broker-launch --scope user
-ExecReload=@bindir@/busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
 Slice=session.slice
 
 [Install]


### PR DESCRIPTION
dbus-broker supports reload but the service type is `notify`. This PR updates the service type to `notify-reload`.