### PR TITLE
util/audit: Correct usage of audit logging functions

### DIFF
--- a/src/util/audit.c
+++ b/src/util/audit.c
@@ -121,7 +121,11 @@ int util_audit_log(int type, const char *message, uid_t uid) {
         }
 
         if (audit_fd >= 0 && type != UTIL_AUDIT_TYPE_NOAUDIT) {
-                r = audit_log_user_avc_message(audit_fd, audit_type, message, NULL, NULL, NULL, uid);
+                if (type == UTIL_AUDIT_TYPE_AVC) {
+                        r = audit_log_user_avc_message(audit_fd, audit_type, message, NULL, NULL, NULL, uid);
+                } else {
+                        r = audit_log_user_message(audit_fd, audit_type, message, NULL, NULL, NULL, 1);
+                }
                 if (r <= 0)
                         return error_origin(-errno);
         } else {


### PR DESCRIPTION
Update util_audit_log to use audit_log_user_message for UTIL_AUDIT_TYPE_POLICYLOAD and UTIL_AUDIT_TYPE_MAC_STATUS, and audit_log_user_avc_message for UTIL_AUDIT_TYPE_AVC. The result parameter is now passed to audit_log_user_message, set to 1 by default.

This change ensures proper argument order for ausearch utility as discussed in linux-audit/audit-userspace#394.

Fixes #387