### PR TITLE
util/sockopt: also check for ESRCH when the process has exited

### DIFF
--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -238,7 +238,7 @@ int sockopt_get_peerpidfd(int fd, int *pidfdp) {
                         return SOCKOPT_E_UNSUPPORTED;
                 if (errno == ENODATA)
                         return SOCKOPT_E_UNAVAILABLE;
-                if (errno == EINVAL)
+                if (errno == EINVAL || errno == ESRCH)
                         return SOCKOPT_E_REAPED;
 
                 return error_origin(-errno);


### PR DESCRIPTION
The kernel in 6.16 is changing the return value from EINVAL to ESRCH so that the particular case can be distinguished from generic errors:

https://lore.kernel.org/all/20250411-work-pidfs-enoent-v2-2-60b2d3bb545f@kernel.org/