### PR TITLE
build: add infrastructure for rust

### DIFF
--- a/.github/workflows/meson-tests.yml
+++ b/.github/workflows/meson-tests.yml
@@ -36,31 +36,29 @@ jobs:
         # since it clashes with sd-bus used by the launcher. This test also
         # builds documentation and related resources.
         - id: "release"
-          name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT +DOCS +LAUNCHER +SELINUX"
+          name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT +DOCS +LAUNCHER -SELINUX"
 
           # Explicitly set all options here to document them.
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          m32: "no"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           rustflags: ""
-          setupargs: "-Daudit=true -Ddocs=true -Dlauncher=true -Dselinux=true"
+          setupargs: "-Daudit=true -Ddocs=true -Dlauncher=true"
           test: "yes"
           valgrind: "no"
           warnlevel: "2"
 
-        # A release build with `-m32` to test on 32-bit.
+        # A release build with `--cross-file lib32` to test on 32-bit.
         - id: "32bit"
-          name: "RELEASE @ CLANG-I686 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
+          name: "RELEASE @ CLANG-I686 @ +TEST -VALGRIND @ -APPARMOR -AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "debugoptimized"
           cc: "clang"
-          cflags: "-m32 -Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          m32: "yes"
+          cflags: "-Werror"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           rustflags: "--target i686-unknown-linux-gnu"
-          setupargs: "-Daudit=true -Dlauncher=true"
+          setupargs: "-Dlauncher=true --cross-file lib32"
           test: "yes"
           warnlevel: "2"
 
@@ -73,7 +71,7 @@ jobs:
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           setupargs: "-Daudit=true -Dlauncher=false"
           test: "yes"
           valgrind: "yes"
@@ -82,26 +80,26 @@ jobs:
         # A reduced build with `-O0` to verify we do not rely on dead-code
         # elimination.
         - id: "O0-PLAIN"
-          name: "PLAIN @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER +SELINUX"
+          name: "PLAIN @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "plain"
           cc: "gcc"
           cflags: "-O0 -Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          setupargs: "-Daudit=true -Dlauncher=true -Dselinux=true"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
+          setupargs: "-Daudit=true -Dlauncher=true"
           test: "yes"
           warnlevel: "2"
 
         # An aggressive -O3 -DNDEBUG build that verfies that we properly
         # follow strict aliasing rules and do not rely on debug builds.
         - id: "O3-NDEBUG"
-          name: "OPTIMIZED @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER +SELINUX"
+          name: "OPTIMIZED @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "release"
           cc: "gcc"
           cflags: "-O3 -Werror -DNDEBUG"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          setupargs: "-Daudit=true -Dlauncher=true -Dselinux=true"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
+          setupargs: "-Daudit=true -Dlauncher=true"
           test: "yes"
           warnlevel: "2"
 
@@ -113,11 +111,12 @@ jobs:
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           setupargs: "-Dlauncher=false"
           test: "yes"
           warnlevel: "2"
 
+        # Run on Ubuntu to test the AppArmor integration.
         - id: "ubuntu"
           name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ +APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
@@ -131,24 +130,17 @@ jobs:
 
     container:
       image: ${{ matrix.image }}
+      options: --user root
 
     env:
       CC: ${{ matrix.cc }}
       CFLAGS: ${{ matrix.cflags }}
-      RUSTFLAGS: ${{ matrix.rustflags }}
 
     runs-on: "ubuntu-latest"
 
     steps:
     - name: "Fetch Sources"
       uses: actions/checkout@v4
-
-    - name: "Setup 32-bit Environment"
-      if: matrix.m32 == 'yes'
-      run: |
-        echo \
-          "PKG_CONFIG_LIBDIR=/usr/lib/pkgconfig:/usr/share/pkgconfig" \
-          >> $GITHUB_ENV
 
     - name: "Setup Meson"
       run: |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additionally, the compatibility launcher requires:
 At build-time, the following software is required:
 
 ```
-  meson >= 0.60
+  meson >= 1.3
   pkg-config >= 0.29
   python-docutils >= 0.13
   linux-api-headers >= 4.13

--- a/meson.build
+++ b/meson.build
@@ -6,32 +6,36 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
-                'rust_std=2024',
+                'rust_std=2021',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=1.7.0',
+        meson_version: '>=1.3',
         version: '36',
 )
 
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_version = '>=0.71.0'
+bindgen_msv = '>=0.60'
+rust_edition = '2021'
+rust_msv = '1.74'
+
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
 mod_rust = import('rust')
 rust = meson.get_compiler('rust')
-rust_edition = '2024'
-rust_msrv = '1.85'
 
 #
 # System Requirements
 #
 
-if rust.version().version_compare('<' + rust_msrv)
-        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+if rust.version().version_compare('<' + rust_msv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
+
+bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_version = bindgen_prog.version()
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -6,17 +6,32 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
+                'rust_std=2024',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=0.60.0',
+        meson_version: '>=1.7.0',
         version: '36',
 )
 
 add_languages('c', native: false)
+add_languages('rust', native: false)
 
+bindgen_version = '>=0.71.0'
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
+mod_rust = import('rust')
+rust = meson.get_compiler('rust')
+rust_edition = '2024'
+rust_msrv = '1.85'
+
+#
+# System Requirements
+#
+
+if rust.version().version_compare('<' + rust_msrv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+endif
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ project(
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_msv = '>=0.60'
+bindgen_msv = '0.60'
 rust_edition = '2021'
 rust_msv = '1.74'
 
@@ -34,7 +34,7 @@ if rust.version().version_compare('<' + rust_msv)
         error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
 
-bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_prog = find_program('bindgen', native: true, required: true, version: '>=' + bindgen_msv)
 bindgen_version = bindgen_prog.version()
 
 #

--- a/src/clib.rs
+++ b/src/clib.rs
@@ -1,0 +1,1 @@
+//! # C-Rust Bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,25 @@
+//! # Rust Bus Library
+//!
+//! This library combines all Rust utilities of dbus-broker. It is linked to
+//! most executables of dbus-broker as utility library, relying on link-time
+//! garbage collection to drop any unneeded code.
+
+/// # Generated Code
+///
+/// This module exposes all bindgen-generated (or otherwise generated) code,
+/// and makes it available to the entire crate.
+///
+/// Note that any C/Rust interaction is done via bindgen-generated C
+/// definitions, to guarantee that the Rust and C definitions never get out
+/// of sync.
+pub(crate) mod generated {
+}
+
+#[cfg(test)]
+mod test {
+    // Simple dummy to show the test-suite in the test results, even if
+    // other tests are conditionally disabled.
+    #[test]
+    fn availability() {
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,9 @@ sources_bus = [
         'util/user.c',
 ]
 
+bindgen_bus = [
+]
+
 deps_bus = [
         dep_cdvar,
         dep_clist,
@@ -110,6 +113,40 @@ else
         ]
 endif
 
+bindgen_args = [
+        '--formatter=prettyplease',
+        '--rust-edition=' + rust_edition,
+]
+
+bindgen_generated = []
+
+foreach i : bindgen_bus
+        bindgen_generated += mod_rust.bindgen(
+                args: bindgen_args + [
+                        '--allowlist-file=.*/' + i,
+                ],
+                bindgen_version: bindgen_version,
+                dependencies: deps_bus,
+                include_directories: incs_bus,
+                input: i,
+                # `foo-bar.h` -> `foo_bar.rs`
+                output: i.substring(0, -2).underscorify() + '.rs',
+        )
+endforeach
+
+rust_bus = static_library(
+        'rbus',
+        structured_sources(
+                [
+                        'lib.rs',
+                ],
+                {
+                        'generated': bindgen_generated,
+                },
+        ),
+        rust_abi: 'c',
+)
+
 static_bus = static_library(
         'bus-static',
         sources_bus,
@@ -118,6 +155,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
+        link_with: rust_bus,
         pic: true,
 )
 
@@ -175,6 +213,12 @@ endif
 #
 # target: test-*
 #
+
+mod_rust.test(
+        'rbus-tests',
+        rust_bus,
+        suite: 'unit',
+)
 
 test_kwargs = {
         'dependencies': dep_bus,

--- a/src/meson.build
+++ b/src/meson.build
@@ -114,8 +114,10 @@ else
 endif
 
 bindgen_args = [
-        '--formatter=prettyplease',
-        '--rust-edition=' + rust_edition,
+        '--formatter', 'prettyplease',
+        '--rust-edition', rust_edition,
+        '--rust-target', rust_msrv,
+        '--use-core',
 ]
 
 bindgen_generated = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -115,10 +115,15 @@ endif
 
 bindgen_args = [
         '--formatter', 'prettyplease',
-        '--rust-edition', rust_edition,
-        '--rust-target', rust_msrv,
         '--use-core',
 ]
+
+if bindgen_version.version_compare('>=0.71')
+        bindgen_args += [
+                '--rust-edition', rust_edition,
+                '--rust-target', rust_msv,
+        ]
+endif
 
 bindgen_generated = []
 
@@ -127,7 +132,6 @@ foreach i : bindgen_bus
                 args: bindgen_args + [
                         '--allowlist-file=.*/' + i,
                 ],
-                bindgen_version: bindgen_version,
                 dependencies: deps_bus,
                 include_directories: incs_bus,
                 input: i,

--- a/src/meson.build
+++ b/src/meson.build
@@ -138,12 +138,18 @@ rust_bus = static_library(
         'rbus',
         structured_sources(
                 [
-                        'lib.rs',
+                        'rlib.rs',
                 ],
                 {
                         'generated': bindgen_generated,
                 },
         ),
+)
+
+crust_bus = static_library(
+        'crbus',
+        ['clib.rs'],
+        link_with: rust_bus,
         rust_abi: 'c',
 )
 
@@ -155,7 +161,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
-        link_with: rust_bus,
+        link_with: crust_bus,
         pic: true,
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -228,6 +228,14 @@ mod_rust.test(
         suite: 'unit',
 )
 
+if meson.version().version_compare('>=1.8')
+        mod_rust.doctest(
+                'rbus-doctests',
+                rust_bus,
+                suite: 'unit',
+        )
+endif
+
 test_kwargs = {
         'dependencies': dep_bus,
         'install': use_tests,

--- a/src/meson.build
+++ b/src/meson.build
@@ -232,7 +232,7 @@ mod_rust.test(
         suite: 'unit',
 )
 
-if meson.version().version_compare('>=1.8')
+if meson.version().version_compare('>=1.8') and not meson.is_cross_build()
         mod_rust.doctest(
                 'rbus-doctests',
                 rust_bus,

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -17,7 +17,10 @@ extern crate core;
 /// Note that any C/Rust interaction is done via bindgen-generated C
 /// definitions, to guarantee that the Rust and C definitions never get out
 /// of sync.
-pub(crate) mod generated {
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+pub mod generated {
 }
 
 #[cfg(test)]

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -4,6 +4,11 @@
 //! most executables of dbus-broker as utility library, relying on link-time
 //! garbage collection to drop any unneeded code.
 
+#![no_std]
+
+extern crate alloc;
+extern crate core;
+
 /// # Generated Code
 ///
 /// This module exposes all bindgen-generated (or otherwise generated) code,


### PR DESCRIPTION
Extend the Meson build system to compile an internal Rust library and link that into `libbus.a`, our internal utility library that is linked into all dbus-broker binaries.

The individual commits have extensive information on, and background for, the individual changes. To summarize, we now use the builtin Rust support of Meson to compile a static library that uses no external dependencies but standard Rust `core` and `alloc`, as well as the runtime-integration of `std`. This avoids the previous dance via `meson-cargo`, and it makes the build fully independent of `Cargo`.

This series merely extends the build system, but adds no meaningful Rust code. This will be added in other PRs.