### PR TITLE
Add some standard stats to Debug.GetStats method

### DIFF
--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -2581,6 +2581,19 @@ static void test_stats(void) {
 
                                 r = sd_bus_message_exit_container(reply);
                                 c_assert(r >= 0);
+                        } else if (strcmp(stat, "Serial") == 0 ||
+                                   strcmp(stat, "ActiveConnections") == 0 ||
+                                   strcmp(stat, "IncompleteConnections") == 0 ||
+                                   strcmp(stat, "BusNames") == 0 ||
+                                   strcmp(stat, "MatchRules") == 0) {
+                                r = sd_bus_message_enter_container(reply, 'v', "u");
+                                c_assert(r >= 0);
+
+                                r = sd_bus_message_skip(reply, "u");
+                                c_assert(r >= 0);
+
+                                r = sd_bus_message_exit_container(reply);
+                                c_assert(r >= 0);
                         } else {
                                 r = sd_bus_message_skip(reply, "v");
                                 c_assert(r >= 0);


### PR DESCRIPTION
This adds standard fields as expected by the org.freedesktop.DBus.Debug.Stats.GetStats method:
- Serial
- ActiveConnections
- IncompleteConnections
- MatchRules
- BusNames

Since these fields are essentially summing the per-namespace stats over all peers, these stats are easy to gather. However, this commit does not expose Peak* stats as these would require tracking max matches and bus names over the lifetime of dbus-broker. Arguably, the # of connections, match rules and bus names are more important.

See #390