### PR TITLE
Silence new GCC warnings

### DIFF
--- a/src/util/string.h
+++ b/src/util/string.h
@@ -78,7 +78,8 @@ _c_pure_ static inline char *string_prefix(const char *str, const char *prefix) 
  * destination buffer must be at least twice as big as the source.
  */
 static inline void string_to_hex(const char *str, size_t n, char *hex) {
-        static const char table[16] = "0123456789abcdef";
+        // Include terminating NUL to silence warnings about truncated strings.
+        static const char table[17] = "0123456789abcdef";
         size_t i;
 
         for (i = 0; i < n; ++i) {

--- a/src/util/systemd.c
+++ b/src/util/systemd.c
@@ -15,7 +15,8 @@ static bool needs_escape(char c) {
 }
 
 static char *escape_char(char *t, char c) {
-        static const char table[16] = "0123456789abcdef";
+        // Include terminating NUL to silence warnings about truncated strings.
+        static const char table[17] = "0123456789abcdef";
 
         *t++ = '\\';
         *t++ = 'x';


### PR DESCRIPTION
Again some warnings of GCC that will break builds with `-Werror` but are false positives. See each one for details.