### PR TITLE
packit: skip automatic README updates

### DIFF
--- a/packit.yml
+++ b/packit.yml
@@ -1,3 +1,4 @@
+create_sync_note: false
 downstream_package_name: "dbus-broker"
 upstream_package_name: "dbus-broker"
 upstream_tag_template: "v{version}"


### PR DESCRIPTION
The downstream dist-git is still manually managed by us, so avoid the automatic README updates.