### PR TITLE
util/acct: implement a new hierarchical accounting system

### DIFF
--- a/.github/workflows/meson-tests.yml
+++ b/.github/workflows/meson-tests.yml
@@ -36,31 +36,29 @@ jobs:
         # since it clashes with sd-bus used by the launcher. This test also
         # builds documentation and related resources.
         - id: "release"
-          name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT +DOCS +LAUNCHER +SELINUX"
+          name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT +DOCS +LAUNCHER -SELINUX"
 
           # Explicitly set all options here to document them.
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          m32: "no"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           rustflags: ""
-          setupargs: "-Daudit=true -Ddocs=true -Dlauncher=true -Dselinux=true"
+          setupargs: "-Daudit=true -Ddocs=true -Dlauncher=true"
           test: "yes"
           valgrind: "no"
           warnlevel: "2"
 
-        # A release build with `-m32` to test on 32-bit.
+        # A release build with `--cross-file lib32` to test on 32-bit.
         - id: "32bit"
-          name: "RELEASE @ CLANG-I686 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
+          name: "RELEASE @ CLANG-I686 @ +TEST -VALGRIND @ -APPARMOR -AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "debugoptimized"
           cc: "clang"
-          cflags: "-m32 -Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          m32: "yes"
+          cflags: "-Werror"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           rustflags: "--target i686-unknown-linux-gnu"
-          setupargs: "-Daudit=true -Dlauncher=true"
+          setupargs: "-Dlauncher=true --cross-file lib32"
           test: "yes"
           warnlevel: "2"
 
@@ -73,7 +71,7 @@ jobs:
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           setupargs: "-Daudit=true -Dlauncher=false"
           test: "yes"
           valgrind: "yes"
@@ -82,26 +80,26 @@ jobs:
         # A reduced build with `-O0` to verify we do not rely on dead-code
         # elimination.
         - id: "O0-PLAIN"
-          name: "PLAIN @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER +SELINUX"
+          name: "PLAIN @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "plain"
           cc: "gcc"
           cflags: "-O0 -Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          setupargs: "-Daudit=true -Dlauncher=true -Dselinux=true"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
+          setupargs: "-Daudit=true -Dlauncher=true"
           test: "yes"
           warnlevel: "2"
 
         # An aggressive -O3 -DNDEBUG build that verfies that we properly
         # follow strict aliasing rules and do not rely on debug builds.
         - id: "O3-NDEBUG"
-          name: "OPTIMIZED @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER +SELINUX"
+          name: "OPTIMIZED @ GCC-X86_64 @ +TEST -VALGRIND @ -APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
           buildtype: "release"
           cc: "gcc"
           cflags: "-O3 -Werror -DNDEBUG"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
-          setupargs: "-Daudit=true -Dlauncher=true -Dselinux=true"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
+          setupargs: "-Daudit=true -Dlauncher=true"
           test: "yes"
           warnlevel: "2"
 
@@ -113,11 +111,12 @@ jobs:
           buildtype: "debugoptimized"
           cc: "clang"
           cflags: "-Werror"
-          image: "ghcr.io/bus1/dbrk-ci-fedora:latest"
+          image: "ghcr.io/readaheadeu/rae-ci-archlinux:latest"
           setupargs: "-Dlauncher=false"
           test: "yes"
           warnlevel: "2"
 
+        # Run on Ubuntu to test the AppArmor integration.
         - id: "ubuntu"
           name: "RELEASE @ CLANG-X86_64 @ +TEST -VALGRIND @ +APPARMOR +AUDIT -DOCS +LAUNCHER -SELINUX"
 
@@ -131,24 +130,17 @@ jobs:
 
     container:
       image: ${{ matrix.image }}
+      options: --user root
 
     env:
       CC: ${{ matrix.cc }}
       CFLAGS: ${{ matrix.cflags }}
-      RUSTFLAGS: ${{ matrix.rustflags }}
 
     runs-on: "ubuntu-latest"
 
     steps:
     - name: "Fetch Sources"
       uses: actions/checkout@v4
-
-    - name: "Setup 32-bit Environment"
-      if: matrix.m32 == 'yes'
-      run: |
-        echo \
-          "PKG_CONFIG_LIBDIR=/usr/lib/pkgconfig:/usr/share/pkgconfig" \
-          >> $GITHUB_ENV
 
     - name: "Setup Meson"
       run: |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additionally, the compatibility launcher requires:
 At build-time, the following software is required:
 
 ```
-  meson >= 0.60
+  meson >= 1.3
   pkg-config >= 0.29
   python-docutils >= 0.13
   linux-api-headers >= 4.13

--- a/meson.build
+++ b/meson.build
@@ -6,32 +6,36 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
-                'rust_std=2024',
+                'rust_std=2021',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=1.7.0',
+        meson_version: '>=1.3',
         version: '36',
 )
 
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_version = '>=0.71.0'
+bindgen_msv = '>=0.60'
+rust_edition = '2021'
+rust_msv = '1.74'
+
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
 mod_rust = import('rust')
 rust = meson.get_compiler('rust')
-rust_edition = '2024'
-rust_msrv = '1.85'
 
 #
 # System Requirements
 #
 
-if rust.version().version_compare('<' + rust_msrv)
-        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+if rust.version().version_compare('<' + rust_msv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
+
+bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_version = bindgen_prog.version()
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -6,17 +6,32 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
+                'rust_std=2024',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=0.60.0',
+        meson_version: '>=1.7.0',
         version: '36',
 )
 
 add_languages('c', native: false)
+add_languages('rust', native: false)
 
+bindgen_version = '>=0.71.0'
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
+mod_rust = import('rust')
+rust = meson.get_compiler('rust')
+rust_edition = '2024'
+rust_msrv = '1.85'
+
+#
+# System Requirements
+#
+
+if rust.version().version_compare('<' + rust_msrv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+endif
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ project(
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_msv = '>=0.60'
+bindgen_msv = '0.60'
 rust_edition = '2021'
 rust_msv = '1.74'
 
@@ -34,7 +34,7 @@ if rust.version().version_compare('<' + rust_msv)
         error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
 
-bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_prog = find_program('bindgen', native: true, required: true, version: '>=' + bindgen_msv)
 bindgen_version = bindgen_prog.version()
 
 #

--- a/src/clib.rs
+++ b/src/clib.rs
@@ -1,0 +1,1 @@
+//! # C-Rust Bridge

--- a/src/clib.rs
+++ b/src/clib.rs
@@ -1,1 +1,39 @@
 //! # C-Rust Bridge
+//!
+//! XXX
+
+mod acct {
+    use rbus::generated::util_acct;
+    use rbus::util::acct;
+
+    #[unsafe(export_name = "acct_new")]
+    pub extern "C" fn acct_new(
+        acctp: *mut *mut util_acct::Acct,
+        maxima: *const [::core::ffi::c_ulong; acct::N_SLOTS],
+    ) -> ::core::ffi::c_int {
+        unsafe {
+            let acct = acct::Acct::new(&*maxima);
+            *acctp = std::rc::Rc::into_raw(acct) as *mut _;
+        }
+        0
+    }
+
+    #[unsafe(export_name = "acct_free")]
+    pub extern "C" fn acct_free(
+        acct_c: *mut util_acct::Acct,
+    ) -> *mut util_acct::Acct {
+        let _ = unsafe { std::rc::Rc::from_raw(acct_c) };
+        core::ptr::null_mut()
+    }
+
+    /*
+    #[unsafe(export_name = "acct_user_ref")]
+    pub extern "C" fn user_ref(
+        user: *mut util_acct::AcctUser,
+    ) -> *mut util_acct::AcctUser {
+        let u = unsafe { rc::Rc::from_raw(user as *mut User) };
+        core::mem::forget(u.clone());
+        user
+    }
+    */
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,25 @@
+//! # Rust Bus Library
+//!
+//! This library combines all Rust utilities of dbus-broker. It is linked to
+//! most executables of dbus-broker as utility library, relying on link-time
+//! garbage collection to drop any unneeded code.
+
+/// # Generated Code
+///
+/// This module exposes all bindgen-generated (or otherwise generated) code,
+/// and makes it available to the entire crate.
+///
+/// Note that any C/Rust interaction is done via bindgen-generated C
+/// definitions, to guarantee that the Rust and C definitions never get out
+/// of sync.
+pub(crate) mod generated {
+}
+
+#[cfg(test)]
+mod test {
+    // Simple dummy to show the test-suite in the test results, even if
+    // other tests are conditionally disabled.
+    #[test]
+    fn availability() {
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,9 @@ sources_bus = [
         'util/user.c',
 ]
 
+bindgen_bus = [
+]
+
 deps_bus = [
         dep_cdvar,
         dep_clist,
@@ -110,6 +113,40 @@ else
         ]
 endif
 
+bindgen_args = [
+        '--formatter=prettyplease',
+        '--rust-edition=' + rust_edition,
+]
+
+bindgen_generated = []
+
+foreach i : bindgen_bus
+        bindgen_generated += mod_rust.bindgen(
+                args: bindgen_args + [
+                        '--allowlist-file=.*/' + i,
+                ],
+                bindgen_version: bindgen_version,
+                dependencies: deps_bus,
+                include_directories: incs_bus,
+                input: i,
+                # `foo-bar.h` -> `foo_bar.rs`
+                output: i.substring(0, -2).underscorify() + '.rs',
+        )
+endforeach
+
+rust_bus = static_library(
+        'rbus',
+        structured_sources(
+                [
+                        'lib.rs',
+                ],
+                {
+                        'generated': bindgen_generated,
+                },
+        ),
+        rust_abi: 'c',
+)
+
 static_bus = static_library(
         'bus-static',
         sources_bus,
@@ -118,6 +155,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
+        link_with: rust_bus,
         pic: true,
 )
 
@@ -175,6 +213,12 @@ endif
 #
 # target: test-*
 #
+
+mod_rust.test(
+        'rbus-tests',
+        rust_bus,
+        suite: 'unit',
+)
 
 test_kwargs = {
         'dependencies': dep_bus,

--- a/src/meson.build
+++ b/src/meson.build
@@ -114,8 +114,10 @@ else
 endif
 
 bindgen_args = [
-        '--formatter=prettyplease',
-        '--rust-edition=' + rust_edition,
+        '--formatter', 'prettyplease',
+        '--rust-edition', rust_edition,
+        '--rust-target', rust_msrv,
+        '--use-core',
 ]
 
 bindgen_generated = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -138,12 +138,18 @@ rust_bus = static_library(
         'rbus',
         structured_sources(
                 [
-                        'lib.rs',
+                        'rlib.rs',
                 ],
                 {
                         'generated': bindgen_generated,
                 },
         ),
+)
+
+crust_bus = static_library(
+        'crbus',
+        ['clib.rs'],
+        link_with: rust_bus,
         rust_abi: 'c',
 )
 
@@ -155,7 +161,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
-        link_with: rust_bus,
+        link_with: crust_bus,
         pic: true,
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -228,6 +228,14 @@ mod_rust.test(
         suite: 'unit',
 )
 
+if meson.version().version_compare('>=1.8')
+        mod_rust.doctest(
+                'rbus-doctests',
+                rust_bus,
+                suite: 'unit',
+        )
+endif
+
 test_kwargs = {
         'dependencies': dep_bus,
         'install': use_tests,

--- a/src/meson.build
+++ b/src/meson.build
@@ -115,10 +115,15 @@ endif
 
 bindgen_args = [
         '--formatter', 'prettyplease',
-        '--rust-edition', rust_edition,
-        '--rust-target', rust_msrv,
         '--use-core',
 ]
+
+if bindgen_version.version_compare('>=0.71')
+        bindgen_args += [
+                '--rust-edition', rust_edition,
+                '--rust-target', rust_msv,
+        ]
+endif
 
 bindgen_generated = []
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -233,7 +233,7 @@ mod_rust.test(
         suite: 'unit',
 )
 
-if meson.version().version_compare('>=1.8')
+if meson.version().version_compare('>=1.8') and not meson.is_cross_build()
         mod_rust.doctest(
                 'rbus-doctests',
                 rust_bus,

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,6 +49,7 @@ sources_bus = [
 ]
 
 bindgen_bus = [
+        'util/acct.h',
 ]
 
 deps_bus = [
@@ -149,6 +150,9 @@ rust_bus = static_library(
                 ],
                 {
                         'generated': bindgen_generated,
+                        'util': [
+                                'util/acct.rs',
+                        ],
                 },
         ),
 )

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -4,6 +4,11 @@
 //! most executables of dbus-broker as utility library, relying on link-time
 //! garbage collection to drop any unneeded code.
 
+#![no_std]
+
+extern crate alloc;
+extern crate core;
+
 /// # Generated Code
 ///
 /// This module exposes all bindgen-generated (or otherwise generated) code,

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -20,6 +20,14 @@ extern crate core;
 #[allow(dead_code)]
 #[allow(non_camel_case_types)]
 pub mod generated {
+    pub mod util_acct;
+}
+
+/// # Utilities
+///
+/// A collection of independent utilities for the bus broker.
+pub mod util {
+    pub mod acct;
 }
 
 #[cfg(test)]

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -17,7 +17,9 @@ extern crate core;
 /// Note that any C/Rust interaction is done via bindgen-generated C
 /// definitions, to guarantee that the Rust and C definitions never get out
 /// of sync.
-pub(crate) mod generated {
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+pub mod generated {
 }
 
 #[cfg(test)]

--- a/src/util/acct.h
+++ b/src/util/acct.h
@@ -1,0 +1,69 @@
+#pragma once
+
+/*
+ * Resource Accounting
+ */
+
+#include <c-stdaux.h>
+#include <stdlib.h>
+
+typedef uint32_t acct_id_t;
+typedef uint64_t acct_value_t;
+
+typedef struct Acct Acct;
+typedef struct AcctActor AcctActor;
+typedef struct AcctCharge AcctCharge;
+typedef struct AcctUser AcctUser;
+
+enum: int {
+        _ACCT_E_SUCCESS,
+
+        ACCT_E_QUOTA,
+};
+
+enum: size_t {
+        ACCT_SLOT_BYTES,
+        ACCT_SLOT_FDS,
+        ACCT_SLOT_MATCHES,
+        ACCT_SLOT_OBJECTS,
+        _ACCT_SLOT_N,
+};
+
+/* charge */
+
+struct AcctCharge {
+        void *usage;
+        acct_value_t amount[_ACCT_SLOT_N];
+};
+
+#define ACCT_CHARGE_INIT {}
+
+void acct_charge_init(AcctCharge *charge);
+void acct_charge_deinit(AcctCharge *charge);
+
+/* acct */
+
+int acct_new(Acct **acctp, const acct_value_t (*maxima)[_ACCT_SLOT_N]);
+Acct *acct_free(Acct *acct);
+
+int acct_ref_user(Acct *acct, AcctUser **userp, acct_id_t id);
+int acct_new_actor(Acct *acct, AcctActor **actorp);
+
+/* user */
+
+AcctUser *acct_user_ref(AcctUser *user);
+AcctUser *acct_user_unref(AcctUser *user);
+
+int acct_user_charge(
+        AcctUser *user,
+        AcctCharge *charge,
+        const acct_value_t (*const amount)[_ACCT_SLOT_N]
+);
+
+/* actor */
+
+int acct_actor_charge(
+        AcctActor *actor,
+        AcctCharge *charge,
+        const acct_value_t (*const amount)[_ACCT_SLOT_N]
+);

--- a/src/util/acct.rs
+++ b/src/util/acct.rs
@@ -1,0 +1,760 @@
+//! # Resource Accounting
+//!
+//! XXX
+//!
+//! ```
+//! use rbus::util::acct;
+//! let acct = acct::Acct::new(&[1024; acct::N_SLOTS]);
+//! ```
+
+// XXX: Drop when done.
+#![allow(dead_code)]
+
+use alloc::{collections::btree_map, rc};
+use core::{cell, convert};
+use crate::generated::util_acct;
+
+/// Representation of user IDs in the accounting system. This is guaranteed to
+/// be a primitive unsigned integer big enough to hold Linux UIDs. Currently
+/// set to `u32`.
+pub type Id = util_acct::acct_id_t;
+
+/// Representation of resource counters in the accounting system. This is
+/// guaranteed to be a primitive unsigned integer. Currently set to `u64`.
+pub type Value = util_acct::acct_value_t;
+
+/// Number of resource slots in the accounting system. That is, it defines how
+/// many different (and independent) resource types are in use and tracked by
+/// the accounting system.
+pub const N_SLOTS: usize = util_acct::_ACCT_SLOT_N;
+
+struct Claim {
+    available: [Value; N_SLOTS],
+    claimed: [Value; N_SLOTS],
+}
+
+struct AcctInner {
+    users: btree_map::BTreeMap<Id, rc::Weak<User>>,
+    maxima: [Value; N_SLOTS],
+}
+
+/// The root context of an independent accounting system. All objects of the
+/// module are eventually tied to one [`Acct`] object. Different such objects
+/// are fully independent.
+///
+/// The root context is used to gain access to [`User`] and [`Actor`] objects,
+/// and provides the initial resource constraints of the system.
+pub struct Acct {
+    inner: cell::RefCell<AcctInner>,
+}
+
+struct UserInner {
+    acct: rc::Rc<Acct>,
+    id: Id,
+    quotas: btree_map::BTreeMap<Id, rc::Weak<Quota>>,
+    maxima: [Value; N_SLOTS],
+    claim: Claim,
+}
+
+/// A user of the accounting system is an independent entity that is granted a
+/// fixed resource limit. An [`Actor`] can then claim resources of a user up to
+/// the limit of the user. If the actor is tied to the user it claims from,
+/// then it can claim up to the resource limit. If the actor is tied to another
+/// user, then its resource claims are subject to a quota.
+pub struct User {
+    inner: cell::RefCell<UserInner>,
+}
+
+struct ActorInner {
+    user: rc::Rc<User>,
+    trace: rc::Rc<Trace>,
+}
+
+/// An actor is used to claim resources of a user. Every actor operates on
+/// behalf of a user, and as such is tied to that user. If an actor claims
+/// resources of its own user, it will get full access. If an actor claims
+/// resources of a foreign user, it will be subject to a quota.
+pub struct Actor {
+    inner: cell::RefCell<ActorInner>,
+}
+
+struct QuotaInner {
+    user: rc::Rc<User>,
+    id: Id,
+    traces: btree_map::BTreeMap<*const Actor, rc::Weak<Trace>>,
+    claim: Claim,
+}
+
+struct Quota {
+    inner: cell::RefCell<QuotaInner>,
+}
+
+struct TraceInner {
+    quota: rc::Rc<Quota>,
+    actor: *const Actor,
+    claim: Claim,
+}
+
+struct Trace {
+    inner: cell::RefCell<TraceInner>,
+}
+
+// Calculate the ceiled base-2 logarithm, rounding up in case of missing
+// precision.
+//
+// If `v` is 0, or negative, the function will produce a result, but does not
+// give guarantees on its value (currently, it will produce the maximum
+// logarithm representable).
+fn log2_ceil(v: Value) -> Value {
+    let length: u32 = Value::BITS;
+
+    // This calculates the ceiled logarithm. What we do is count the leading
+    // zeros of the value in question and then substract it from its
+    // bit-length. By subtracting one from the value first we make sure the
+    // value is ceiled.
+    //
+    // Hint: To calculate the floored value, you would do the subtraction of 1
+    //       from the final value, rather than from the source value:
+    //
+    //           `length - v.leading_zeros() - 1`
+    let log2: u32 = length - (v - 1).leading_zeros();
+
+    // Convert the value back into the source type. Since the source type must
+    // be an integer type, it must have a representation for all integers
+    // between its original and 0. Hence, this cannot fail.
+    convert::From::from(log2)// as Value
+}
+
+/// A resource allocator that provides exponential allocation guarantees. It
+/// ensures resource reserves are freely accessible, at the expense of granting
+/// only very limited guarantees to each entity.
+///
+/// This allocator grants access to half of the remaining resources for every
+/// new allocation. As such, this allocator guarantees that each independent
+/// entity gets access to 1 over `2^n` of the total resources.
+pub fn allocator_exponential(_users: Value) -> Option<Value> {
+    Some(2)
+}
+
+/// A resource allocator that provides polynomial allocation guarantees. It
+/// ensures resource reserves are easily accessible, at the expense of granting
+/// only limited guarantees to each entity.
+///
+/// This allocator grants access to 1 over `n` of the remaining resources for
+/// every new allocation (with `n` being the number of active entities). As
+/// such, this allocator guarantees that each independent entity gets access to
+/// 1 over `n^2` of the total resources.
+pub fn allocator_polynomial(users: Value) -> Option<Value> {
+    users.checked_add(1)
+}
+
+/// A resource allocator that provides quasilinear allocation guarantees. It
+/// ensures strong guarantees to each entity, at the expense of heavily
+/// restricting resource reserves.
+///
+/// This allocator grants access to 1 over `n log(n) + n` of the remaining
+/// resources for every new allocation (with `n` being the number of active
+/// entities). As such, this allocator guarantees that each independent
+/// entity gets access to 1 over `n log(n)^2` of the total resources.
+pub fn allocator_quasilinear(users: Value) -> Option<Value> {
+    let Some(users1) = users.checked_add(1) else { return None };
+    let Some(log_mul) = log2_ceil(users1).checked_mul(users1) else { return None };
+    log_mul.checked_add(users1)
+}
+
+/// Calculate the minimum reserve size required for an allocation request to
+/// pass the quota.
+///
+/// Whenever an allocation request is checked against the quota, this function
+/// can be used to calculate how many resources must still be available in the
+/// reserve to allow the request. If this minimum reserve size matches the size
+/// of the request, the allocation would be allowed to consume all remaining
+/// resources. In most cases, this function returns a bigger minimum reserve
+/// size, to ensure future requests can be served as well.
+///
+/// This function implements an algorithm to allow an unknown set of users to
+/// fairly share a fixed pool of resources. It considers the changing parameters
+/// and adjusts its quota check accordingly, ensuring that a growing or
+/// shrinking set of users get arbitrated access to the available resources
+/// in a fair manner.
+///
+/// The quota-check is applied whenever a user requests resources from the
+/// shared resource pool. The following information is involved in checking a
+/// quota:
+///
+/// * `remaining`: Amount of resources that are available for allocation
+/// * `n_users`: Number of users that are tracked, including the claimant user
+/// * `share`: Amount of resources the claimant user has already allocated
+/// * `charge`: Amount of resources that are requested by the claimant user
+///
+/// ## Algorithm
+///
+/// Ideally, every user on the system would get `1 / n_users` of the available
+/// resources. This would be a fair system, where everyone gets the same share.
+/// Unfortunately, we do not know the number of users that will participate
+/// upfront. Hence, we use an algorithm that guarantees something that comes
+/// close to this ideal.
+///
+/// An allocation that was granted is never revoked, nor do we reclaim any
+/// resources that are actively used. Hence, the only place the algorithm is
+/// applied is when an allocation is requested. There, we look at the amount
+/// of resources that are still available, and then decide whether the user
+/// is allowed their request. We consider every allocation of a user as a
+/// `re-allocation` of their current share. That is, we pretend they release
+/// their currently held resources, then request a new allocation that is the
+/// size of the original request plus their previous share. This `re-allocation`
+/// then has to satisfy the following inequality:
+///
+/// ```txt
+///                       remaining + share
+///     charge + share <= ~~~~~~~~~~~~~~~~~
+///                           A(n_users)
+/// ```
+///
+/// In other words, of the remaining resources, a user gets a fraction that
+/// only depends on the number of users that are active. Now depending on which
+/// function `A()` is chosen, a user can request more or less resources.
+/// However, selection of `A()` also affects the overall guarantees that the
+/// algorithm will provide.
+///
+/// For example, consider `A(n): 2`. That is, an allocator that always grants
+/// half of the remaining resources to a user:
+///
+/// ```txt
+///                       remaining + share
+///     charge + share <= ~~~~~~~~~~~~~~~~~
+///                               2
+/// ```
+///
+/// This will ensure that resources are easily available and little reserves
+/// are kept. However, for a single user, this allocation scheme can only
+/// guarantee that each user gets `1 / 2^n` of the available resources. So
+/// while it ensures that resources are easily available and not held back,
+/// it also prevents any meaningful guarantess for a single user, and as such
+/// denials of service can ensue.
+///
+/// If, on the other hand, you pick `A(n): n + 1`, then only a share
+/// proportional to the number of currently active users is granted:
+///
+/// ```txt
+///                       remaining + share
+///     charge + share <= ~~~~~~~~~~~~~~~~~
+///                          n_users + 1
+/// ```
+///
+/// (Note that `n_users` is not the total numbers of users involved in the
+/// system eventually, but merely at the given moment).
+///
+/// With this allocator, much bigger reserves are kept as the number of users
+/// rises. Ultimately, this will guarantee that each users gets `1 / n^2` of
+/// the total resources. This is already much better than the exponential
+/// backoff of the previous allocator.
+///
+/// Now, lastly, we consider `A(n): n log(n) + n`, or more precicesly
+/// `A(n): (n+1) log(n+1) + n+1`. With this allocator, resources are kept
+/// even tighter, but ultimately we get a quasilinear guarantee for each user
+/// with `1 / (n * log(n)^2)`. This is already pretty close to the ideal of
+/// `1 / n`.
+///
+/// ## Hierarchy
+///
+/// The algorithm can be applied to a hierarchical setup by simply chaining
+/// quota checks. For instance, one could first check whether a user can
+/// allocate resources from a global resource pool, and then check whether a
+/// claimant can allocate resources on that user. Depending on what guarantees
+/// are desired on each level, different allocators can be chosen. However,
+/// any hierarchical setup will also significantly reduce the guarantees, as
+/// each level operates only on the guarantees of the previous level.
+fn quota_reserve<F>(
+    allocator_fn: F,
+    n_users: Value,
+    share: Value,
+    charge: Value,
+) -> Option<Value>
+where
+    F: Fn(Value) -> Option<Value>,
+{
+    // For a quota check, we have to calculate:
+    //
+    //                       remaining + share
+    //     charge + share <= ~~~~~~~~~~~~~~~~~
+    //                           A(n_users)
+    //
+    // But to avoid the division, we instead calculate:
+    //
+    //     (charge + share) * A(n_users) - share <= remaining
+    //
+    // The inequality itself has to be checked by the caller. This function
+    // merely computes the left half of the inequality and returns it.
+    //
+    // None of these partial calculations exceed the actual limit by a factor
+    // of 2, and as such we expect all calculations to be possible within the
+    // limits of the integer type. Any overflow will thus result in a quota
+    // rejection.
+
+    let Some(allocator) = allocator_fn(n_users) else { return None };
+    let Some(charge_share) = charge.checked_add(share) else { return None };
+    let Some(limit) = charge_share.checked_mul(allocator) else { return None };
+    let Some(minimum) = limit.checked_sub(share) else { return None };
+
+    Some(minimum)
+}
+
+/// Search a map of weak-refs for an entry with the given key. Upgrade to a
+/// strong-ref and return it. If either the upgrade fails, or if the key is
+/// not present, use `insert_fn` to insert a new entry, and return it.
+fn find_and_upgrade_or_insert_with<K, V, F>(
+    map: &mut btree_map::BTreeMap<K, rc::Weak<V>>,
+    key: &K,
+    insert_fn: F,
+) -> rc::Rc<V>
+where
+    K: Clone + Ord,
+    F: FnOnce() -> rc::Rc<V>,
+{
+    match map.entry(key.clone()) {
+        btree_map::Entry::Vacant(vac) => {
+            let v = insert_fn();
+            vac.insert(rc::Rc::downgrade(&v));
+            v
+        },
+        btree_map::Entry::Occupied(mut occ) => {
+            if let Some(v) = occ.get().upgrade() {
+                v
+            } else {
+                let v = insert_fn();
+                occ.insert(rc::Rc::downgrade(&v));
+                v
+            }
+        },
+    }
+}
+
+impl Claim {
+    fn with(available: &[Value; N_SLOTS]) -> Self {
+        Claim {
+            available: available.clone(),
+            claimed: available.clone(),
+        }
+    }
+
+    fn new() -> Self {
+        Self::with(&[0; N_SLOTS])
+    }
+}
+
+impl Acct {
+    /// XXX
+    pub fn new(maxima: &[Value; N_SLOTS]) -> rc::Rc<Acct> {
+        rc::Rc::new(Self {
+            inner: cell::RefCell::new(
+                AcctInner {
+                    users: btree_map::BTreeMap::new(),
+                    maxima: maxima.clone(),
+                },
+            ),
+        })
+    }
+
+    /// XXX
+    pub fn get_user(self: &rc::Rc<Acct>, id: Id) -> rc::Rc<User> {
+        let mut s_borrow = self.inner.borrow_mut();
+        let s: &mut AcctInner = &mut *s_borrow;
+
+        // Borrow early, so Rust can properly detect that it is a borrow on
+        // a distinct field than `s.users`.
+        let s_maxima = &s.maxima;
+
+        // Find the user, or create a new one.
+        find_and_upgrade_or_insert_with(
+            &mut s.users,
+            &id,
+            || User::new(self, id, s_maxima),
+        )
+    }
+}
+
+impl UserInner {
+    fn quotas_len(&self) -> Value {
+        assert!(size_of::<Value>() >= size_of::<usize>());
+
+        convert::TryFrom::try_from(
+            self.quotas.len()
+        ).unwrap()
+    }
+}
+
+impl User {
+    fn new(
+        acct: &rc::Rc<Acct>,
+        id: Id,
+        maxima: &[Value; N_SLOTS],
+    ) -> rc::Rc<User> {
+        rc::Rc::new(Self {
+            inner: cell::RefCell::new(
+                UserInner {
+                    acct: acct.clone(),
+                    id: id,
+                    quotas: btree_map::BTreeMap::new(),
+                    maxima: maxima.clone(),
+                    claim: Claim::with(maxima),
+                },
+            ),
+        })
+    }
+
+    fn get_quota(self: &rc::Rc<User>, id: Id) -> rc::Rc<Quota> {
+        let mut s = self.inner.borrow_mut();
+
+        // Find the quota, or create a new one.
+        find_and_upgrade_or_insert_with(
+            &mut s.quotas,
+            &id,
+            || Quota::new(self, id),
+        )
+    }
+
+    fn get_quota_self(self: &rc::Rc<User>) -> rc::Rc<Quota> {
+        self.get_quota(self.inner.borrow().id)
+    }
+
+    // XXX
+    pub fn charge(
+        self: &rc::Rc<User>,
+        claimant: &rc::Rc<Actor>,
+        amount: &[Value; N_SLOTS],
+    ) -> Option<util_acct::AcctCharge> {
+        // Resolve all the Rc+RefCell wrappers and pin them for access.
+        let self_inner = &mut *self.inner.borrow_mut();
+        let claimant_inner = claimant.inner.borrow();
+        let claimant_user = claimant_inner.user.inner.borrow();
+        let quota = self.get_quota(claimant_user.id);
+        let trace = quota.get_trace(&rc::Rc::downgrade(claimant));
+        let quota_inner = &mut *quota.inner.borrow_mut();
+        let trace_inner = &mut *trace.inner.borrow_mut();
+
+        // Check whether we cross boundaries.
+        let cross_trace = true;
+        let cross_user = quota_inner.cross_user();
+
+        // Get mutable references to all 3 involved claim objects, so
+        // we can check the quota on them and eventually apply the charge.
+        let n_users = self_inner.quotas_len();
+        let n_actors = quota_inner.traces_len();
+        let claim_user = &mut self_inner.claim;
+        let claim_quota = &mut quota_inner.claim;
+        let claim_trace = &mut trace_inner.claim;
+
+        // Remember the charge amount for each level / claim-object.
+        let mut reqs = [[0; 3]; N_SLOTS];
+
+        // First check the quota on each slot independently, but apply nothing.
+        for slot in 0..N_SLOTS {
+            let req = &mut reqs[slot];
+            let mut minimum;
+
+            req[0] = amount[slot];
+
+            // Direct allocation
+            //
+            // We start the allocation request on the trace object, and work
+            // our way upwards for as long as the request was not fulfilled.
+            //
+            // A trace object is a leaf node in the allocation tree, and as
+            // such cannot have any overallocated resources. Verify this! Then
+            // delegate the request to the next level.
+
+            assert_eq!(claim_trace.available[slot], 0);
+            req[1] = req[0];
+
+            // Trace allocation
+            //
+            // Since the trace object cannot serve the request, we delegate
+            // the allocation and request more resources for this trace object
+            // from the user. This uses a very lenient allocator, since no user
+            // boundaries are crossed, but we merely share resources across
+            // actors of the same user.
+            //
+            // We first calculate how big the reserve of the user has to be
+            // to serve the request, and then check whether the user already
+            // has enough resources available. If not, we delegate the
+            // allocation request to the next level.
+            //
+            // If trace boundaries are not crossed, we grant full access to
+            // all resources.
+
+            minimum = if cross_trace {
+                match quota_reserve(
+                    allocator_exponential,
+                    n_actors,
+                    claim_trace.claimed[slot],
+                    req[1],
+                ) {
+                    None => return None,
+                    Some(v) => v,
+                }
+            } else {
+                req[1]
+            };
+
+            if claim_quota.available[slot] >= minimum {
+                continue;
+            }
+
+            req[2] = minimum - claim_quota.available[slot];
+
+            // User allocation
+            //
+            // The reserve of the user was not big enough to serve the request,
+            // so we have to request more resources for this user. If this
+            // crosses user-boundaries, we have to ensure that a strong
+            // allocator is used. But if this does not cross user-boundaries,
+            // we grant full access to all resources of the user.
+
+            minimum = if cross_user {
+                match quota_reserve(
+                    allocator_quasilinear,
+                    n_users,
+                    claim_quota.claimed[slot],
+                    req[2],
+                ) {
+                    None => return None,
+                    Some(v) => v,
+                }
+            } else {
+                req[2]
+            };
+
+            if claim_user.available[slot] >= minimum {
+                continue;
+            }
+
+            // Root allocation
+            //
+            // The resources of the user were exhausted. We do not support
+            // further propagation, but only provide per-user limits. Hence, we
+            // have to fail the request.
+
+            return None;
+        }
+
+        // With all quotas checked, apply the charge to each slot.
+        for slot in 0..N_SLOTS {
+            let req = &mut reqs[slot];
+
+            claim_user.available[slot] -= req[2];
+            claim_quota.claimed[slot] += req[2];
+            claim_quota.available[slot] += req[2];
+
+            claim_quota.available[slot] -= req[1];
+            claim_trace.claimed[slot] += req[1];
+            claim_trace.available[slot] += req[1];
+
+            claim_trace.available[slot] -= req[0];
+        }
+
+        Some(util_acct::AcctCharge {
+            usage: rc::Rc::into_raw(trace.clone()) as *mut _,
+            amount: amount.clone(),
+        })
+    }
+}
+
+impl core::ops::Drop for User {
+    fn drop(&mut self) {
+        let s_inner = self.inner.get_mut();
+
+        // Ensure the weak-ref is dropped from the user map, so it can be
+        // properly deallocated.
+        s_inner.acct.inner.borrow_mut()
+            .users.remove(&s_inner.id);
+    }
+}
+
+impl Actor {
+    // XXX
+    pub fn with(
+        user: &rc::Rc<User>,
+    ) -> rc::Rc<Actor> {
+        rc::Rc::new_cyclic(
+            |weak| Self {
+                inner: cell::RefCell::new(
+                    ActorInner {
+                        user: user.clone(),
+                        trace: user.get_quota_self().get_trace(weak),
+                    },
+                ),
+            },
+        )
+    }
+
+    // XXX
+    pub fn charge(
+        self: &rc::Rc<Actor>,
+        claimant: &rc::Rc<Actor>,
+        amount: &[Value; N_SLOTS],
+    ) -> Option<util_acct::AcctCharge> {
+        self.inner.borrow()
+            .user.charge(
+                claimant,
+                amount,
+        )
+    }
+}
+
+impl QuotaInner {
+    fn cross_user(&self) -> bool {
+        self.id != self.user.inner.borrow().id
+    }
+
+    fn traces_len(&self) -> Value {
+        assert!(size_of::<Value>() >= size_of::<usize>());
+
+        convert::TryFrom::try_from(
+            self.traces.len()
+        ).unwrap()
+    }
+}
+
+impl Quota {
+    fn new(
+        user: &rc::Rc<User>,
+        id: Id,
+    ) -> rc::Rc<Quota> {
+        rc::Rc::new(Self {
+            inner: cell::RefCell::new(
+                QuotaInner {
+                    user: user.clone(),
+                    id: id,
+                    traces: btree_map::BTreeMap::new(),
+                    claim: Claim::new(),
+                },
+            ),
+        })
+    }
+
+    fn get_trace(
+        self: &rc::Rc<Quota>,
+        actor: &rc::Weak<Actor>,
+    ) -> rc::Rc<Trace> {
+        let mut s = self.inner.borrow_mut();
+
+        // Find the trace, or create a new one.
+        find_and_upgrade_or_insert_with(
+            &mut s.traces,
+            &rc::Weak::as_ptr(&actor),
+            || Trace::new(self, actor),
+        )
+    }
+}
+
+impl core::ops::Drop for Quota {
+    fn drop(&mut self) {
+        let s_inner = self.inner.get_mut();
+
+        // Ensure the weak-ref is dropped from the quota map, so it can be
+        // properly deallocated.
+        s_inner.user.inner.borrow_mut()
+            .quotas.remove(&s_inner.id);
+    }
+}
+
+impl Trace {
+    fn new(
+        quota: &rc::Rc<Quota>,
+        actor: &rc::Weak<Actor>,
+    ) -> rc::Rc<Trace> {
+        rc::Rc::new(Self {
+            inner: cell::RefCell::new(
+                TraceInner {
+                    quota: quota.clone(),
+                    actor: actor.as_ptr(),
+                    claim: Claim::new(),
+                },
+            ),
+        })
+    }
+
+    pub fn discharge(
+        self: &rc::Rc<Trace>,
+        amount: &[Value; N_SLOTS],
+    ) {
+        let trace_inner = &mut *self.inner.borrow_mut();
+        let quota_inner = &mut *trace_inner.quota.inner.borrow_mut();
+        let user_inner = &mut *quota_inner.user.inner.borrow_mut();
+
+        // Get mutable references to all 3 involved claim objects.
+        let n_actors = quota_inner.traces_len();
+        let claim_user = &mut user_inner.claim;
+        let claim_quota = &mut quota_inner.claim;
+        let claim_trace = &mut trace_inner.claim;
+
+        for slot in 0..N_SLOTS {
+            let mut n;
+
+            // Release the amount on the trace-object and make it available as
+            // cached resources. We do this for completeness reasons, but we
+            // immediately release the resources to the next layer in full.
+
+            n = amount[slot];
+
+            claim_trace.available[slot] += n;
+
+            // Release all unused resources on the trace object and grant them
+            // back to the user. We do not want to cache any resources on the
+            // trace object, yet, but always ensure everything is properly
+            // returned to the lower levels.
+
+            n = claim_trace.available[slot];
+
+            claim_trace.available[slot] -= n;
+            claim_trace.claimed[slot] -= n;
+            claim_quota.available[slot] += n;
+
+            // When returning resources to the reserve of the user, we check
+            // how big the reserve needs to be, so we can shrink it if possible
+            // and ensure unneeded resources are always released to lower
+            // levels.
+            //
+            // To figure out how big the reserve needs to be, we simply
+            // calculate the average amount that a trace object has claimed,
+            // and then pretend to allocate that amount. This will calculate
+            // a suitable resource, which we then shrink to. This also ensures
+            // that if the average is 0, the minimum reserve will also be 0.
+
+            let claimed = claim_quota.claimed[slot];
+            let available = claim_quota.available[slot];
+
+            let average = claimed
+                .checked_sub(available)
+                .unwrap()
+                .checked_div(convert::TryFrom::try_from(n_actors).unwrap())
+                .unwrap();
+
+            let minimum = quota_reserve(
+                allocator_exponential,
+                n_actors,
+                average,
+                0,
+            ).unwrap_or(Value::MAX);
+
+            if minimum < claim_quota.available[slot] {
+                n = claim_quota.available[slot] - minimum;
+                claim_quota.available[slot] -= n;
+                claim_quota.claimed[slot] -= n;
+                claim_user.available[slot] += n;
+            }
+        }
+    }
+}
+
+impl core::ops::Drop for Trace {
+    fn drop(&mut self) {
+        let s_inner = self.inner.get_mut();
+
+        // Ensure the weak-ref is dropped from the trace map, so it can be
+        // properly deallocated.
+        s_inner.quota.inner.borrow_mut()
+            .traces.remove(&s_inner.actor);
+    }
+}


### PR DESCRIPTION
This is a replacement for `util/user.[ch]`. It is written in Rust, but
exposes a C API that can be used by dbus-broker.

The new accounting system uses the `acct_*` namespace to ease the
transition and avoid naming conflicts. Furthermore, the system is
written in Rust and relies on the new build-system support for Rust
code (see #392).

Note that this is a single commit on top of #392. Once the Rust support is merged, this rebase is not necessary, anymore. Also note that this only introduces the accounting system as an alternative, it does not disable the old one, yet.

The accounting system works with the same algorithm as the previous
flat-accounting model, but extends it to a 2-layered hierarchy. The
algorithm is adopted to support an arbitrarily nested hierarchy, but the
code will only expose 2 layers:

1) As before, all users are assigned a flat resource limit that they get
   full control over. But when user boundaries are crossed, a quota is
   applied to guarantee fair resource sharing. The algorithm used is
   still the `fairdist`, but the allocators were improved on.

2) Beneath the user quotas, a new layer is introduced. Rather than users
   claiming resources, now all operations originate from an `Actor`.
   These always operate on behalf of a user, but allow us to distinguish
   different actors of the same user. A new resource tracing system is
   now added analog to the user quotas. It operates above the quotas and
   ensures we can semi-protect individual actors of the same user (which
   was not possible before). We do not provide a fully fair policy on
   this level, however, since no privilege boundaries are crossed.
   Instead, this provides a semi-fair policy which is a lot more
   lenient, but still allows us to protect against failing clients.