### PR TITLE
build: add infrastructure for rust (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additionally, the compatibility launcher requires:
 At build-time, the following software is required:
 
 ```
-  meson >= 0.60
+  meson >= 1.3
   pkg-config >= 0.29
   python-docutils >= 0.13
   linux-api-headers >= 4.13

--- a/meson.build
+++ b/meson.build
@@ -6,17 +6,32 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
+                'rust_std=2024',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=0.60.0',
+        meson_version: '>=1.7.0',
         version: '37',
 )
 
 add_languages('c', native: false)
+add_languages('rust', native: false)
 
+bindgen_version = '>=0.71.0'
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
+mod_rust = import('rust')
+rust = meson.get_compiler('rust')
+rust_edition = '2024'
+rust_msrv = '1.85'
+
+#
+# System Requirements
+#
+
+if rust.version().version_compare('<' + rust_msrv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+endif
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -6,32 +6,36 @@ project(
         'dbus-broker',
         default_options: [
                 'c_std=c11',
-                'rust_std=2024',
+                'rust_std=2021',
         ],
         license: 'Apache-2.0',
-        meson_version: '>=1.7.0',
+        meson_version: '>=1.3',
         version: '37',
 )
 
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_version = '>=0.71.0'
+bindgen_msv = '>=0.60'
+rust_edition = '2021'
+rust_msv = '1.74'
+
 cc = meson.get_compiler('c')
 conf = configuration_data()
 mod_pkgconfig = import('pkgconfig')
 mod_rust = import('rust')
 rust = meson.get_compiler('rust')
-rust_edition = '2024'
-rust_msrv = '1.85'
 
 #
 # System Requirements
 #
 
-if rust.version().version_compare('<' + rust_msrv)
-        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msrv)
+if rust.version().version_compare('<' + rust_msv)
+        error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
+
+bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_version = bindgen_prog.version()
 
 #
 # Mandatory Dependencies

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ project(
 add_languages('c', native: false)
 add_languages('rust', native: false)
 
-bindgen_msv = '>=0.60'
+bindgen_msv = '0.60'
 rust_edition = '2021'
 rust_msv = '1.74'
 
@@ -34,7 +34,7 @@ if rust.version().version_compare('<' + rust_msv)
         error('Found Rust ' + rust.version() + ' but requires >=' + rust_msv)
 endif
 
-bindgen_prog = find_program('bindgen', native: true, required: true, version: bindgen_msv)
+bindgen_prog = find_program('bindgen', native: true, required: true, version: '>=' + bindgen_msv)
 bindgen_version = bindgen_prog.version()
 
 #

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,12 @@ if use_docs
 endif
 
 #
+# Config: doctest
+#
+
+use_doctest = get_option('doctest')
+
+#
 # Config: launcher
 #
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('apparmor', type: 'boolean', value: false, description: 'AppArmor support')
 option('audit', type: 'boolean', value: false, description: 'Audit support')
 option('docs', type: 'boolean', value: false, description: 'Build documentation')
+option('doctest', type: 'boolean', value: false, description: 'Test code of documentation')
 option('launcher', type: 'boolean', value: true, description: 'Build compatibility launcher')
 option('linux-4-17', type: 'boolean', value: false, description: 'Require linux-4.17 at runtime and make use of its features')
 option('reference-test', type: 'boolean', value: false, description: 'Run test suite against reference implementation')

--- a/src/clib.rs
+++ b/src/clib.rs
@@ -1,0 +1,1 @@
+//! # C-Rust Bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,25 @@
+//! # Rust Bus Library
+//!
+//! This library combines all Rust utilities of dbus-broker. It is linked to
+//! most executables of dbus-broker as utility library, relying on link-time
+//! garbage collection to drop any unneeded code.
+
+/// # Generated Code
+///
+/// This module exposes all bindgen-generated (or otherwise generated) code,
+/// and makes it available to the entire crate.
+///
+/// Note that any C/Rust interaction is done via bindgen-generated C
+/// definitions, to guarantee that the Rust and C definitions never get out
+/// of sync.
+pub(crate) mod generated {
+}
+
+#[cfg(test)]
+mod test {
+    // Simple dummy to show the test-suite in the test results, even if
+    // other tests are conditionally disabled.
+    #[test]
+    fn availability() {
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,9 @@ sources_bus = [
         'util/user.c',
 ]
 
+bindgen_bus = [
+]
+
 deps_bus = [
         dep_cdvar,
         dep_clist,
@@ -110,6 +113,40 @@ else
         ]
 endif
 
+bindgen_args = [
+        '--formatter=prettyplease',
+        '--rust-edition=' + rust_edition,
+]
+
+bindgen_generated = []
+
+foreach i : bindgen_bus
+        bindgen_generated += mod_rust.bindgen(
+                args: bindgen_args + [
+                        '--allowlist-file=.*/' + i,
+                ],
+                bindgen_version: bindgen_version,
+                dependencies: deps_bus,
+                include_directories: incs_bus,
+                input: i,
+                # `foo-bar.h` -> `foo_bar.rs`
+                output: i.substring(0, -2).underscorify() + '.rs',
+        )
+endforeach
+
+rust_bus = static_library(
+        'rbus',
+        structured_sources(
+                [
+                        'lib.rs',
+                ],
+                {
+                        'generated': bindgen_generated,
+                },
+        ),
+        rust_abi: 'c',
+)
+
 static_bus = static_library(
         'bus-static',
         sources_bus,
@@ -118,6 +155,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
+        link_with: rust_bus,
         pic: true,
 )
 
@@ -175,6 +213,12 @@ endif
 #
 # target: test-*
 #
+
+mod_rust.test(
+        'rbus-tests',
+        rust_bus,
+        suite: 'unit',
+)
 
 test_kwargs = {
         'dependencies': dep_bus,

--- a/src/meson.build
+++ b/src/meson.build
@@ -114,8 +114,10 @@ else
 endif
 
 bindgen_args = [
-        '--formatter=prettyplease',
-        '--rust-edition=' + rust_edition,
+        '--formatter', 'prettyplease',
+        '--rust-edition', rust_edition,
+        '--rust-target', rust_msrv,
+        '--use-core',
 ]
 
 bindgen_generated = []

--- a/src/meson.build
+++ b/src/meson.build
@@ -115,10 +115,15 @@ endif
 
 bindgen_args = [
         '--formatter', 'prettyplease',
-        '--rust-edition', rust_edition,
-        '--rust-target', rust_msrv,
         '--use-core',
 ]
+
+if bindgen_version.version_compare('>=0.71')
+        bindgen_args += [
+                '--rust-edition', rust_edition,
+                '--rust-target', rust_msv,
+        ]
+endif
 
 bindgen_generated = []
 
@@ -127,7 +132,6 @@ foreach i : bindgen_bus
                 args: bindgen_args + [
                         '--allowlist-file=.*/' + i,
                 ],
-                bindgen_version: bindgen_version,
                 dependencies: deps_bus,
                 include_directories: incs_bus,
                 input: i,

--- a/src/meson.build
+++ b/src/meson.build
@@ -236,7 +236,7 @@ if meson.version().version_compare('>=1.8') and not meson.is_cross_build()
         mod_rust.doctest(
                 'rbus-doctests',
                 rust_bus,
-                suite: 'unit',
+                suite: 'doctest',
         )
 endif
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -138,12 +138,18 @@ rust_bus = static_library(
         'rbus',
         structured_sources(
                 [
-                        'lib.rs',
+                        'rlib.rs',
                 ],
                 {
                         'generated': bindgen_generated,
                 },
         ),
+)
+
+crust_bus = static_library(
+        'crbus',
+        ['clib.rs'],
+        link_with: rust_bus,
         rust_abi: 'c',
 )
 
@@ -155,7 +161,7 @@ static_bus = static_library(
                 '-fno-common',
         ],
         dependencies: deps_bus,
-        link_with: rust_bus,
+        link_with: crust_bus,
         pic: true,
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -232,7 +232,7 @@ mod_rust.test(
         suite: 'unit',
 )
 
-if meson.version().version_compare('>=1.8') and not meson.is_cross_build()
+if use_doctest and meson.version().version_compare('>=1.8')
         mod_rust.doctest(
                 'rbus-doctests',
                 rust_bus,

--- a/src/meson.build
+++ b/src/meson.build
@@ -228,6 +228,14 @@ mod_rust.test(
         suite: 'unit',
 )
 
+if meson.version().version_compare('>=1.8')
+        mod_rust.doctest(
+                'rbus-doctests',
+                rust_bus,
+                suite: 'unit',
+        )
+endif
+
 test_kwargs = {
         'dependencies': dep_bus,
         'install': use_tests,

--- a/src/meson.build
+++ b/src/meson.build
@@ -232,7 +232,7 @@ mod_rust.test(
         suite: 'unit',
 )
 
-if meson.version().version_compare('>=1.8')
+if meson.version().version_compare('>=1.8') and not meson.is_cross_build()
         mod_rust.doctest(
                 'rbus-doctests',
                 rust_bus,

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -4,6 +4,11 @@
 //! most executables of dbus-broker as utility library, relying on link-time
 //! garbage collection to drop any unneeded code.
 
+#![no_std]
+
+extern crate alloc;
+extern crate core;
+
 /// # Generated Code
 ///
 /// This module exposes all bindgen-generated (or otherwise generated) code,

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -17,7 +17,13 @@ extern crate core;
 /// Note that any C/Rust interaction is done via bindgen-generated C
 /// definitions, to guarantee that the Rust and C definitions never get out
 /// of sync.
-pub(crate) mod generated {
+#[allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+)]
+pub mod generated {
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Extend the Meson build system to compile an internal Rust library and link that into libbus.a, our internal utility library that is linked into all dbus-broker binaries.

The individual commits have extensive information on, and background for, the individual changes. To summarize, we now use the builtin Rust support of Meson to compile a static library that uses no external dependencies but standard Rust core and alloc, as well as the runtime-integration of std. This avoids the previous dance via meson-cargo, and it makes the build fully independent of Cargo.

This series merely extends the build system, but adds no meaningful Rust code. This will be added in other PRs.

(v2: rebased on the recent CI changes)
