### PR TITLE
util/audit: do not handle non-auditable messages

### DIFF
--- a/src/broker/main.c
+++ b/src/broker/main.c
@@ -302,7 +302,7 @@ int main(int argc, char **argv) {
                 }
         }
 
-        r = bus_selinux_init_global();
+        r = bus_selinux_init_global(&log);
         if (r) {
                 r = error_fold(r);
                 goto exit;

--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -179,7 +179,7 @@ static int bus_apparmor_log(BusAppArmorRegistry *registry, const char *fmt, ...)
          * the right UID to use, follow dbus-daemon(1) and use our
          * own. */
         r = util_audit_log(UTIL_AUDIT_TYPE_AVC, message, getuid());
-        if (r)
+        if (r != UTIL_AUDIT_E_UNAVAILABLE) // XXX: use a log fallback
                 return error_fold(r);
 
         return 0;

--- a/src/util/audit-fallback.c
+++ b/src/util/audit-fallback.c
@@ -22,13 +22,7 @@ int util_audit_drop_permissions(uint32_t uid, uint32_t gid) {
 }
 
 int util_audit_log(int type, const char *message, uid_t uid) {
-        int r;
-
-        r = fprintf(stderr, "%s\n", message);
-        if (r < 0)
-                return error_origin(r);
-
-        return 0;
+        return UTIL_AUDIT_E_UNAVAILABLE;
 }
 
 int util_audit_init_global(void) {

--- a/src/util/audit.h
+++ b/src/util/audit.h
@@ -8,7 +8,12 @@
 #include <stdlib.h>
 
 enum {
-        UTIL_AUDIT_TYPE_NOAUDIT,
+        _UTIL_AUDIT_E_SUCCESS,
+
+        UTIL_AUDIT_E_UNAVAILABLE,
+};
+
+enum {
         UTIL_AUDIT_TYPE_AVC,
         UTIL_AUDIT_TYPE_POLICYLOAD,
         UTIL_AUDIT_TYPE_MAC_STATUS,

--- a/src/util/selinux-fallback.c
+++ b/src/util/selinux-fallback.c
@@ -53,7 +53,7 @@ int bus_selinux_check_send(BusSELinuxRegistry *registry,
         return 0;
 }
 
-int bus_selinux_init_global(void) {
+int bus_selinux_init_global(Log *log) {
         return 0;
 }
 

--- a/src/util/selinux.c
+++ b/src/util/selinux.c
@@ -323,18 +323,33 @@ static int bus_selinux_log_fn(int type, const char *fmt, ...) {
                  * the right UID to use, follow dbus-daemon(1) and use our
                  * own. */
                 r = util_audit_log(UTIL_AUDIT_TYPE_AVC, message, getuid());
-                if (r)
+                if (r == UTIL_AUDIT_E_UNAVAILABLE) {
+                        loghdr = "selinux/avc";
+                        loglvl = LOG_INFO;
+                } else if (r) {
                         return error_fold(r);
+                }
+
                 break;
         case SELINUX_POLICYLOAD:
                 r = util_audit_log(UTIL_AUDIT_TYPE_POLICYLOAD, message, getuid());
-                if (r)
+                if (r == UTIL_AUDIT_E_UNAVAILABLE) {
+                        loghdr = "selinux/policyload";
+                        loglvl = LOG_INFO;
+                } else if (r) {
                         return error_fold(r);
+                }
+
                 break;
         case SELINUX_SETENFORCE:
                 r = util_audit_log(UTIL_AUDIT_TYPE_MAC_STATUS, message, getuid());
-                if (r)
+                if (r == UTIL_AUDIT_E_UNAVAILABLE) {
+                        loghdr = "selinux/macstatus";
+                        loglvl = LOG_INFO;
+                } else if (r) {
                         return error_fold(r);
+                }
+
                 break;
         case SELINUX_ERROR:
                 loghdr = "selinux/error";

--- a/src/util/selinux.h
+++ b/src/util/selinux.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 typedef struct BusSELinuxRegistry BusSELinuxRegistry;
+typedef struct Log Log;
 
 enum {
         _SELINUX_E_SUCCESS,
@@ -34,5 +35,5 @@ int bus_selinux_check_send(BusSELinuxRegistry *registry,
                            const char *context_sender,
                            const char *context_receiver);
 
-int bus_selinux_init_global(void);
+int bus_selinux_init_global(Log *log);
 void bus_selinux_deinit_global(void);


### PR DESCRIPTION
A minor rework of the audit/selinux/apparmor subsystems to avoid handling non-auditable messages and instead forwarding them to our own log.