### PR TITLE
bus/driver: add some standard stats to Debug.GetStats

### DIFF
--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -46,6 +46,7 @@ struct Bus {
 
         UserRegistry users;
         NameRegistry names;
+        MatchCounters match_counters;
         MatchRegistry wildcard_matches;
         MatchRegistry sender_matches;
         PeerRegistry peers;
@@ -61,6 +62,7 @@ struct Bus {
                 .pid_fd = -1,                                                   \
                 .users = USER_REGISTRY_NULL,                                    \
                 .names = NAME_REGISTRY_INIT,                                    \
+                .match_counters = MATCH_COUNTERS_INIT,                          \
                 .wildcard_matches = MATCH_REGISTRY_INIT((_x).wildcard_matches), \
                 .sender_matches = MATCH_REGISTRY_INIT((_x).sender_matches),     \
                 .peers = PEER_REGISTRY_INIT,                                    \

--- a/src/bus/bus.h
+++ b/src/bus/bus.h
@@ -54,6 +54,7 @@ struct Bus {
         uint64_t n_monitors;
         uint64_t listener_ids;
         uint64_t activation_ids;
+        uint64_t stats_ids;
 
         Metrics metrics;
 };

--- a/src/bus/match.h
+++ b/src/bus/match.h
@@ -11,6 +11,7 @@
 #include "dbus/address.h"
 #include "util/user.h"
 
+typedef struct MatchCounters MatchCounters;
 typedef struct MatchFilter MatchFilter;
 typedef struct MatchKeys MatchKeys;
 typedef struct MatchOwner MatchOwner;
@@ -71,6 +72,7 @@ struct MatchRule {
         MatchRegistry *registry;
         MatchOwner *owner;
         CRBNode owner_node;
+        MatchCounters *counters;
 
         UserCharge charge[2];
         MatchKeys keys;
@@ -85,6 +87,7 @@ struct MatchRule {
         }
 
 struct MatchOwner {
+        size_t n_owner_subscriptions;
         CRBTree rule_tree;
         CList destinations_link;
 };
@@ -161,12 +164,20 @@ struct MatchRegistry {
                 .monitor_tree = C_RBTREE_INIT,          \
         }
 
+struct MatchCounters {
+        size_t n_subscriptions;
+        size_t n_subscriptions_peak;
+        size_t n_owner_subscriptions_peak;
+};
+
+#define MATCH_COUNTERS_INIT {}
+
 /* rules */
 
 MatchRule *match_rule_user_ref(MatchRule *rule);
 MatchRule *match_rule_user_unref(MatchRule *rule);
 
-int match_rule_link(MatchRule *rule, MatchRegistry *registry, bool monitor);
+int match_rule_link(MatchRule *rule, MatchCounters *counters, MatchRegistry *registry, bool monitor);
 void match_rule_unlink(MatchRule *rule);
 
 C_DEFINE_CLEANUP(MatchRule *, match_rule_user_unref);

--- a/src/bus/name.h
+++ b/src/bus/name.h
@@ -76,6 +76,7 @@ struct Name {
         }
 
 struct NameOwner {
+        size_t n_owner_primaries;
         CRBTree ownership_tree;
 };
 
@@ -84,6 +85,9 @@ struct NameOwner {
         }
 
 struct NameRegistry {
+        size_t n_primaries;
+        size_t n_primaries_peak;
+        size_t n_owner_primaries_peak;
         CRBTree name_tree;
 };
 

--- a/src/bus/peer.c
+++ b/src/bus/peer.c
@@ -298,6 +298,7 @@ int peer_new_with_fd(Peer **peerp,
         *peer = (Peer)PEER_INIT(*peer);
 
         peer->bus = bus;
+        ++peer->bus->peers.n_peers;
         peer->user = user;
         user = NULL;
         peer->pid = ucred.pid;
@@ -378,6 +379,7 @@ Peer *peer_free(Peer *peer) {
         free(peer->seclabel);
         free(peer->gids);
         user_unref(peer->user);
+        --peer->bus->peers.n_peers;
         free(peer);
 
         close(fd);
@@ -394,12 +396,14 @@ void peer_register(Peer *peer) {
         c_assert(!peer->monitor);
 
         peer->registered = true;
+        ++peer->bus->peers.n_registered;
 }
 
 void peer_unregister(Peer *peer) {
         c_assert(peer->registered);
         c_assert(!peer->monitor);
 
+        --peer->bus->peers.n_registered;
         peer->registered = false;
 }
 

--- a/src/bus/peer.h
+++ b/src/bus/peer.h
@@ -96,6 +96,8 @@ struct Peer {
 struct PeerRegistry {
         CRBTree peer_tree;
         uint64_t ids;
+        size_t n_peers;
+        size_t n_registered;
 };
 
 #define PEER_REGISTRY_INIT {}

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -229,3 +229,8 @@ int util_drop_permissions(uint32_t uid, uint32_t gid) {
 
         return 0;
 }
+
+void util_peak_update(size_t *peak, size_t update) {
+        if (update > *peak)
+                *peak = update;
+}

--- a/src/util/misc.c
+++ b/src/util/misc.c
@@ -213,6 +213,44 @@ uint64_t util_umul64_saturating(uint64_t a, uint64_t b) {
         return res;
 }
 
+/**
+ * util_z2u_saturating() - saturating cast of size_t to unsigned int
+ * @v:                  value to cast
+ *
+ * This will cast a value of `size_t` to `unsigned int`, saturating the
+ * value at `UINT_MAX` in case of overflow.
+ *
+ * Return: The casted, saturated value is returned.
+ */
+unsigned int util_z2u_saturating(size_t v) {
+        unsigned int cast;
+
+        cast = (unsigned int)v;
+        if ((size_t)cast < v)
+                return UINT_MAX;
+        else
+                return cast;
+}
+
+/**
+ * util_t2u_saturating() - saturating cast of uint64_t to unsigned int
+ * @v:                  value to cast
+ *
+ * This will cast a value of `uint64_t` to `unsigned int`, saturating the
+ * value at `UINT_MAX` in case of overflow.
+ *
+ * Return: The casted, saturated value is returned.
+ */
+unsigned int util_t2u_saturating(uint64_t v) {
+        unsigned int cast;
+
+        cast = (unsigned int)v;
+        if ((uint64_t)cast < v)
+                return UINT_MAX;
+        else
+                return cast;
+}
+
 int util_drop_permissions(uint32_t uid, uint32_t gid) {
         int r;
 

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -26,3 +26,5 @@ int misc_memfd_get_seals(int fd, unsigned int *sealsp);
 
 uint64_t util_umul64_saturating(uint64_t a, uint64_t b);
 int util_drop_permissions(uint32_t uid, uint32_t gid);
+
+void util_peak_update(size_t *peak, size_t update);

--- a/src/util/misc.h
+++ b/src/util/misc.h
@@ -25,6 +25,8 @@ int misc_memfd_add_seals(int fd, unsigned int seals);
 int misc_memfd_get_seals(int fd, unsigned int *sealsp);
 
 uint64_t util_umul64_saturating(uint64_t a, uint64_t b);
+unsigned int util_z2u_saturating(size_t v);
+unsigned int util_t2u_saturating(uint64_t v);
 int util_drop_permissions(uint32_t uid, uint32_t gid);
 
 void util_peak_update(size_t *peak, size_t update);

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -2581,6 +2581,23 @@ static void test_stats(void) {
 
                                 r = sd_bus_message_exit_container(reply);
                                 c_assert(r >= 0);
+                        } else if (strcmp(stat, "Serial") == 0 ||
+                                   strcmp(stat, "ActiveConnections") == 0 ||
+                                   strcmp(stat, "IncompleteConnections") == 0 ||
+                                   strcmp(stat, "BusNames") == 0 ||
+                                   strcmp(stat, "PeakBusNames") == 0 ||
+                                   strcmp(stat, "PeakBusNamesPerConnection") == 0 ||
+                                   strcmp(stat, "MatchRules") == 0 ||
+                                   strcmp(stat, "PeakMatchRules") == 0 ||
+                                   strcmp(stat, "PeakMatchRulesPerConnection") == 0) {
+                                r = sd_bus_message_enter_container(reply, 'v', "u");
+                                c_assert(r >= 0);
+
+                                r = sd_bus_message_skip(reply, "u");
+                                c_assert(r >= 0);
+
+                                r = sd_bus_message_exit_container(reply);
+                                c_assert(r >= 0);
                         } else {
                                 r = sd_bus_message_skip(reply, "v");
                                 c_assert(r >= 0);


### PR DESCRIPTION
Extend the name, bus, and peer registries to keep track of the number of active entries, as well as their peak values. This information is then exposed via `GetStats()`, as documented in the specification.

This contains a rebase of #393, making use of the new infrastructure.