### PR TITLE
build: enable _TIME_BITS=64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ dep_thread = dependency('threads')
 #
 
 add_project_arguments(dep_cstdaux.get_variable('cflags').split(' '), language: 'c')
+add_project_arguments('-D_TIME_BITS=64', language: 'c')
 add_project_arguments('-DBINDIR="' + join_paths(get_option('prefix'), get_option('bindir')) + '"', language: 'c')
 add_project_arguments('-DPACKAGE_VERSION=' + meson.project_version(), language: 'c')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -133,6 +133,10 @@ foreach i : bindgen_bus
                 args: bindgen_args + [
                         '--allowlist-file=.*/' + i,
                 ],
+                c_args: [
+                        # MSMV(1.9.1): With 1.9.1 this is set by Meson.
+                        '-D_FILE_OFFSET_BITS=64',
+                ],
                 dependencies: deps_bus,
                 include_directories: incs_bus,
                 input: i,


### PR DESCRIPTION
Ensure we use 64-bit time handling even for 32-bit machines. We do not expose 3rd party libraries, nor do we consume any libraries outside of our control. Hence, we can safely enable _TIME_BITS=64.