### PR TITLE
util/fdlist: clear cmsg buffers

### DIFF
--- a/src/util/fdlist.c
+++ b/src/util/fdlist.c
@@ -29,7 +29,7 @@
 int fdlist_new_with_fds(FDList **listp, const int *fds, size_t n_fds) {
         FDList *list;
 
-        list = malloc(sizeof(*list) + CMSG_SPACE(n_fds * sizeof(int)));
+        list = calloc(1, sizeof(*list) + CMSG_SPACE(n_fds * sizeof(int)));
         if (!list)
                 return error_origin(-ENOMEM);
 


### PR DESCRIPTION
Clear the cmsg buffers that are allocated by FDList, even if we happen to write them fully. This is not a security issue, but still can show up as problem in sanitizers.

So far, we did not zero out the cmsg buffers, since we assume that we write them fully, and because we know that the kernel does not copy padding. Unfortunately, sanitizers like valgrind will complain about trailing padding that is uninitialized.

We could simply try clearing the trailing padding. However, the CMSG helpers are written in a way to obscure whether intermediary padding will be present. This means, if we want to be entirely sure that all padding is cleared, we better clear the entire buffer.

This is a theoretical issue, since none of the supported linux platforms use intermediary padding. But lets be on the safe side and just clear things right away.