### PR TITLE
apparmor: fix segfault when no interface is available while building query

### DIFF
--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -240,7 +240,8 @@ static int build_message_query_name(
         len += strlen(receiver_context) + 1;
         len += strlen(name) + 1;
         len += strlen(path) + 1;
-        len += strlen(interface) + 1;
+        if (interface)
+                len += strlen(interface) + 1;
         len += strlen(method) + 1;
 
         qstr = malloc(len);
@@ -259,8 +260,10 @@ static int build_message_query_name(
         i += strlen(name) + 1;
         strcpy(qstr+i, path);
         i += strlen(path) + 1;
-        strcpy(qstr+i, interface);
-        i += strlen(interface) + 1;
+        if (interface) {
+                strcpy(qstr+i, interface);
+                i += strlen(interface) + 1;
+        }
         strcpy(qstr+i, method);
 
         *queryp = qstr;


### PR DESCRIPTION
https://bugs.debian.org/1123876

```
 Using host libthread_db library "/usr/lib/x86_64-linux-gnu/libthread_db.so.1".
 Core was generated by `/usr/bin/dbus-broker --log 11 --controller 10 --machine-id 185526166e484f06bc3b47fbfa9dd92a --max-bytes 100000000000000 --max-fds 25000000000000 --max-matches 5000000000'.
 Program terminated with signal SIGSEGV, Segmentation fault.
 #0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:76

 (gdb) bt
 #0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:76
 #1  0x0000558757e05deb in build_message_query_name (queryp=<synthetic pointer>, n_queryp=<synthetic pointer>, security_label=0x55878f319200 "plasmashell", security_label@entry=0x0, bustype=0x55878f1c36e0 "session",
     name=0x55878f3a1020 "unconfined", receiver_context=0x55878f1c7290 "org.freedesktop.Notifications", path=0x55878f4049e0 "/org/kde/solid/UDisks2StorageAccess_1", interface=0x0, method=0x55878f404a20 "passphraseReply")
     at ../src/util/apparmor.c:246
 #2  apparmor_message_query_name (check_send=check_send@entry=false, security_label=security_label@entry=0x55878f319200 "plasmashell", bustype=bustype@entry=0x55878f1c36e0 "session",
     receiver_context=receiver_context@entry=0x55878f3a1020 "unconfined", name=0x55878f1c7290 "org.freedesktop.Notifications", path=path@entry=0x55878f4049e0 "/org/kde/solid/UDisks2StorageAccess_1", interface=0x0,
     method=0x55878f404a20 "passphraseReply", allow=0x7ffce482ab50, audit=0x7ffce482aa6c) at ../src/util/apparmor.c:318
 #3  0x0000558757e06101 in apparmor_message_query (check_send=check_send@entry=false, security_label=security_label@entry=0x55878f319200 "plasmashell", bustype=0x55878f1c36e0 "session",
     receiver_context=receiver_context@entry=0x55878f3a1020 "unconfined", nameset=nameset@entry=0x7ffce482ac90, subject_id=subject_id@entry=36, path=0x55878f4049e0 "/org/kde/solid/UDisks2StorageAccess_1", interface=0x0,
     method=0x55878f404a20 "passphraseReply", allow=0x7ffce482ab50, audit=0x7ffce482ab54) at ../src/util/apparmor.c:388
 #4  0x0000558757e06d58 in bus_apparmor_check_send (registry=0x55878f1c3c70, sender_context=<optimized out>, receiver_context=receiver_context@entry=0x55878f1e1ae0 "plasmashell (complain)",
     subject=subject@entry=0x7ffce482ac90, subject_id=36, path=path@entry=0x55878f4049e0 "/org/kde/solid/UDisks2StorageAccess_1", interface=0x0, method=0x55878f404a20 "passphraseReply") at ../src/util/apparmor.c:559
 #5  0x0000558757dfdd71 in policy_snapshot_check_send (snapshot=snapshot@entry=0x55878f1f2970, subject_seclabel=0x55878f1e1ae0 "plasmashell (complain)", subject=subject@entry=0x7ffce482ac90, subject_id=<optimized out>,
     interface=0x0, method=0x55878f404a20 "passphraseReply", path=0x55878f4049e0 "/org/kde/solid/UDisks2StorageAccess_1", type=1, broadcast=false, n_fds=0) at ../src/bus/policy.c:1067
 #6  0x0000558757dfafd1 in peer_queue_unicast (sender_policy=0x55878f1f2970, sender_names=sender_names@entry=0x7ffce482ad40, sender_replies=sender_replies@entry=0x55878f22c6f0, sender_user=0x55878f1c2570, sender_id=33,
     receiver=0x55878f235ff0, message=0x55878f4044a0) at ../src/bus/peer.c:811
 #7  0x0000558757df4ff4 in driver_forward_unicast (sender=0x55878f22bc70, destination=<optimized out>, message=0x55878f4044a0) at ../src/bus/driver.c:2595
 #8  driver_dispatch_internal (peer=<optimized out>, message=0x55878f4044a0) at ../src/bus/driver.c:2754
 #9  driver_dispatch (peer=peer@entry=0x55878f22bc70, message=0x55878f4044a0) at ../src/bus/driver.c:2778
 #10 0x0000558757df9b4d in peer_dispatch_connection (peer=<optimized out>, events=<optimized out>) at ../src/bus/peer.c:129
 #11 peer_dispatch (file=0x55878f22c620) at ../src/bus/peer.c:201
 #12 0x0000558757e02d05 in dispatch_context_dispatch (ctx=ctx@entry=0x55878f1c1af0) at ../src/util/dispatch.c:343
 #13 0x0000558757de9bf0 in broker_run (broker=0x55878f1c1980) at ../src/broker/broker.c:203
 #14 0x0000558757de8fc3 in run (log=0x7ffce482afe0) at ../src/broker/main.c:280
 #15 main (argc=<optimized out>, argv=0x7ffce482b148) at ../src/broker/main.c:311
```