### PR TITLE
Harmonize error message with the reality

### DIFF
--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -606,7 +606,7 @@ static int launcher_ini_reader_parse_file(Launcher *launcher, CIniGroup **groupp
                 log_append_here(&launcher->log, LOG_ERR, 0, DBUS_BROKER_CATALOG_SERVICE_INVALID);
                 log_append_service_path(&launcher->log, path);
 
-                r = log_commitf(&launcher->log, "Missing 'D-Bus Service' section in service file '%s'\n", path);
+                r = log_commitf(&launcher->log, "Missing 'D-BUS Service' section in service file '%s'\n", path);
                 if (r)
                         return error_fold(r);
 


### PR DESCRIPTION
As can be seen in the code a few lines above, the section is actually called `[D-BUS Service]` (i.e. D-BUS all caps). A user should be able to copy&paste the section name from the error message and not to waste time trying to find out why `[D-Bus Service]` section name is not working for them.