### PR TITLE
dbus: add preliminary support for JSON encoded messages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ dep_cstdaux = dependency('libcstdaux-1', version: '>=1.5.0')
 dep_libc_rs = dependency('libc-rs-0.2', version: '>=0.2.175')
 dep_math = cc.find_library('m')
 dep_osi = dependency('libosi-1', default_options: {'libc': true, 'std': true}, version: '>=1.0.0')
+dep_tmp = dependency('libtmp-1', version: '>=1.0.0')
 dep_thread = dependency('threads')
 
 #

--- a/src/dbus/connection.c
+++ b/src/dbus/connection.c
@@ -22,7 +22,7 @@ static int connection_init(Connection *c,
         int r;
 
         *connection = (Connection)CONNECTION_NULL(*connection);
-        socket_init(&connection->socket, user, fd);
+        socket_init(&connection->socket, user, fd, false);
 
         r = dispatch_file_init(&connection->socket_file,
                                dispatch_ctx,

--- a/src/dbus/message.c
+++ b/src/dbus/message.c
@@ -91,6 +91,39 @@ int message_new_incoming(Message **messagep, MessageHeader header) {
 }
 
 /**
+ * message_new_incoming_json() - create new incoming message object from JSON
+ * @messagep:           output pointer to new message object
+ * @ztv:                zero terminated value
+ * @n_ztv:              length of `ztv` without the terminating zero
+ *
+ * This creates a new message object in @messagep, to hold an incoming message
+ * converted from the JSON message in `ztv`.
+ *
+ * Return: 0 on success, MESSAGE_E_TOO_LARGE if the declared message size
+ *         violates the spec, or a negative error code on failure.
+ */
+int message_new_incoming_json(Message **messagep, const char *ztv, size_t n_ztv) {
+        _c_cleanup_(c_freep) void *data = NULL;
+        size_t n_data = 0;
+        int r;
+
+        /*
+         * XXX: convert `ztv` to `data`
+         * must be native-endian, so: big_endian if (__BYTE_ORDER == __BIG_ENDIAN)
+         */
+
+        if (n_data > MESSAGE_SIZE_MAX)
+                return MESSAGE_E_TOO_LARGE;
+
+        r = message_new_outgoing(messagep, data, n_data);
+        if (r)
+                return error_trace(r);
+        data = NULL;
+
+        return 0;
+}
+
+/**
  * message_new_outgoing() - create a new outgoing message object
  * @messagep:           return pointer to new message object
  * @data:               the message contents

--- a/src/dbus/message.h
+++ b/src/dbus/message.h
@@ -109,6 +109,7 @@ struct MessageHeader {
 } _c_packed_;
 
 int message_new_incoming(Message **messagep, MessageHeader header);
+int message_new_incoming_json(Message **messagep, const char *ztv, size_t n_ztv);
 int message_new_outgoing(Message **messagep, void *data, size_t n_data);
 void message_free(_Atomic unsigned long *n_refs, void *userdata);
 

--- a/src/dbus/queue.h
+++ b/src/dbus/queue.h
@@ -82,6 +82,7 @@ int iqueue_get_cursor(IQueue *iq,
                       UserCharge **charge_fdsp);
 
 int iqueue_pop_line(IQueue *iq, const char **linep, size_t *np);
+int iqueue_pop_ztv(IQueue *iq, const char **ztvp, size_t *np, FDList **fdsp);
 int iqueue_pop_data(IQueue *iq, FDList **fds);
 
 /* inline helpers */

--- a/src/dbus/socket.h
+++ b/src/dbus/socket.h
@@ -38,6 +38,7 @@ struct Socket {
         User *user;
         int fd;
 
+        bool json : 1;
         bool shutdown : 1;
         bool reset : 1;
         bool hup_in : 1;
@@ -62,7 +63,7 @@ struct Socket {
                 .out.pending = C_LIST_INIT((_x).out.pending),           \
         }
 
-void socket_init(Socket *socket, User *user, int fd);
+void socket_init(Socket *socket, User *user, int fd, bool json);
 void socket_deinit(Socket *socket);
 
 int socket_dequeue_line(Socket *socket, const char **linep, size_t *np);

--- a/src/dbus/test-queue.c
+++ b/src/dbus/test-queue.c
@@ -62,8 +62,11 @@ static void test_in_special(void) {
                         c_memcpy(buffer + *from, blob, n);
                         *from += n;
                         total += n;
+                        c_assert(total <= IQUEUE_LINE_MAX);
 
                         r = iqueue_pop_line(&iq, &l, &n);
+                        if (r == IQUEUE_E_VIOLATION)
+                                break;
                         c_assert(r == IQUEUE_E_PENDING);
                 }
 

--- a/src/dbus/test-socket.c
+++ b/src/dbus/test-socket.c
@@ -14,8 +14,8 @@
 static void test_setup(void) {
         _c_cleanup_(socket_deinit) Socket server = SOCKET_NULL(server), client = SOCKET_NULL(client);
 
-        socket_init(&server, NULL, -1);
-        socket_init(&client, NULL, -1);
+        socket_init(&server, NULL, -1, false);
+        socket_init(&client, NULL, -1, false);
 }
 
 static void test_line(void) {
@@ -27,8 +27,8 @@ static void test_line(void) {
         r = socketpair(AF_UNIX, SOCK_STREAM, 0, pair);
         c_assert(r >= 0);
 
-        socket_init(&client, NULL, pair[0]);
-        socket_init(&server, NULL, pair[1]);
+        socket_init(&client, NULL, pair[0], false);
+        socket_init(&server, NULL, pair[1], false);
 
         r = socket_dequeue_line(&server, &line, &n_bytes);
         c_assert(!r && !line);
@@ -69,8 +69,8 @@ static void test_message(void) {
         r = socketpair(AF_UNIX, SOCK_STREAM, 0, pair);
         c_assert(r >= 0);
 
-        socket_init(&client, NULL, pair[0]);
-        socket_init(&server, NULL, pair[1]);
+        socket_init(&client, NULL, pair[0], false);
+        socket_init(&server, NULL, pair[1], false);
 
         r = socket_dequeue(&server, &message2);
         c_assert(!r && !message2);

--- a/src/meson.build
+++ b/src/meson.build
@@ -166,6 +166,7 @@ rbus_crate = static_library(
         dependencies: [
                 dep_libc_rs,
                 dep_osi,
+                dep_tmp,
         ],
         link_with: [
                 rbus_generated,


### PR DESCRIPTION
Use the new D-Bus and JSON modules in `sys/tmp` to allow clients with JSON-based encoding.

This extends the D-Bus socket layer to support zero-byte separated, variable-width message objects. This is then used to get a stream of JSON objects.

JSON objects are always converted to the internally used format (for now DVariant). This keeps modifications to the code-base much simpler and guarantees that all paths work with the same data. Outgoing messages are then converted again directly in the socket layer.

If we decide to fully commit to the new D-Bus module and convert all users in `bus/driver/`, then we can avoid the conversion in most cases. However, for broadcast/multicast messages, we always want to convert messages to ensure each clients gets the properly encoded message.

NB: This is preliminary. The conversion from DVariant to JSON is not
    standardized, nor do we want to commit to it right now. However, we
    want to get feedback and give developers the chance to make use of
    it.
    We definitely intend to stabilize this in the near future.