### PR TITLE
Implement per-UID quota overrides and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+build/
+subprojects/libc-rs-0.2/
+subprojects/libcdvar-1/
+subprojects/libcini-1/
+subprojects/libclist-3/
+subprojects/libcrbtree-3/
+subprojects/libcshquote-1/
+subprojects/libcstdaux-1/
+subprojects/libcutf8-1/
+subprojects/sys-1/
+subprojects/.wraplock

--- a/docs/dbus-broker-launch.rst
+++ b/docs/dbus-broker-launch.rst
@@ -79,6 +79,35 @@ The selected scope does not have any further effect. It is only needed to
 define the activation environment for loaded service definitions. If no
 activatable services are declared, the scope will have no effect at all.
 
+PER-USER QUOTA OVERRIDES
+========================
+
+By default all users share the same resource quotas (``--max-bytes``,
+``--max-fds``, ``--max-matches``, ``--max-objects``) set globally on the
+broker command-line. Individual users can be granted different limits via the
+``<user_quota>`` element in any drop-in configuration file (e.g. a file under
+``/etc/dbus-1/system.d/``).
+
+Example (place in ``/etc/dbus-1/system.d/monitord.conf``):
+
+.. code-block:: xml
+
+    <busconfig>
+      <user_quota user="monitord"
+                  max_bytes="52428800"
+                  max_fds="512"
+                  max_matches="4096"
+                  max_objects="8192"/>
+    </busconfig>
+
+The ``user`` attribute is a username resolved via NSS. An unresolvable name
+logs a warning and is silently skipped. Omitted limit attributes retain the
+global default. Overrides take effect immediately on the already-connected
+peers of that user without requiring a broker restart. They are re-applied
+automatically whenever the configuration is reloaded, including reloads
+triggered by inotify when a drop-in file in a watched directory is added,
+modified, or removed.
+
 SOCKETS
 =======
 

--- a/docs/dbus-broker.rst
+++ b/docs/dbus-broker.rst
@@ -169,6 +169,18 @@ the broker. See the section below for a list of interfaces on the controller.
 |         # standard.
 |         **method** AddMetrics(**o** *path*, **h** *socket*) -> ()
 |
+|         # Override the per-user resource quota for the user identified by
+|         # @uid. The four limits replace the global defaults:
+|         # @max_bytes: maximum bytes the user may have queued
+|         # @max_fds: maximum file descriptors the user may have queued
+|         # @max_matches: maximum match rules the user may install
+|         # @max_objects: maximum total kernel objects (names, peers, etc.)
+|         # the user may own.  The override is applied immediately to any
+|         # already-connected peers of that user and persists for newly
+|         # connecting peers.  Passing UINT32_MAX for a limit resets it to
+|         # the global default.
+|         **method** SetUserQuota(**u** *uid*, **u** *max_bytes*, **u** *max_fds*, **u** *max_matches*, **u** *max_objects*) -> ()
+|
 |         # This signal is raised according to client-requests of
 |         # **org.freedesktop.DBus.UpdateActivationEnvironment()**.
 |         **signal** SetActivationEnvironment(**a{ss}** *environment*)

--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -86,6 +86,17 @@ static const CDVarType controller_type_in_ohv[] = {
                 )
         )
 };
+static const CDVarType controller_type_in_uuuuu[] = {
+        C_DVAR_T_INIT(
+                C_DVAR_T_TUPLE5(
+                        C_DVAR_T_u,
+                        C_DVAR_T_u,
+                        C_DVAR_T_u,
+                        C_DVAR_T_u,
+                        C_DVAR_T_u
+                )
+        )
+};
 static const CDVarType controller_type_in_osu[] = {
         C_DVAR_T_INIT(
                 C_DVAR_T_TUPLE3(
@@ -459,6 +470,25 @@ static int controller_method_name_reset(Controller *controller, const char *path
         return 0;
 }
 
+static int controller_method_set_user_quota(Controller *controller, const char *_path, CDVar *in_v, FDList *fds, CDVar *out_v) {
+        uint32_t uid, max_bytes, max_fds, max_matches, max_objects;
+        int r;
+
+        c_dvar_read(in_v, "(uuuuu)", &uid, &max_bytes, &max_fds, &max_matches, &max_objects);
+
+        r = controller_end_read(in_v);
+        if (r)
+                return error_trace(r);
+
+        r = controller_set_user_quota(controller, (uid_t)uid, max_bytes, max_fds, max_matches, max_objects);
+        if (r)
+                return error_trace(r);
+
+        c_dvar_write(out_v, "()");
+
+        return 0;
+}
+
 static int controller_handle_method(const ControllerMethod *method, Controller *controller, const char *path, uint32_t serial, const char *signature_in, Message *message_in) {
         _c_cleanup_(c_dvar_deinit) CDVar var_in = C_DVAR_INIT, var_out = C_DVAR_INIT;
         _c_cleanup_(message_unrefp) Message *message_out = NULL;
@@ -527,9 +557,10 @@ static int controller_handle_method(const ControllerMethod *method, Controller *
 
 static int controller_dispatch_controller(Controller *controller, uint32_t serial, const char *method, const char *path, const char *signature, Message *message) {
         static const ControllerMethod methods[] = {
-                { "AddName",            controller_method_add_name,     controller_type_in_osu, controller_type_out_unit },
-                { "AddListener",        controller_method_add_listener, controller_type_in_ohv, controller_type_out_unit },
-                { "AddMetrics",         controller_method_add_metrics,  controller_type_in_oh,  controller_type_out_unit },
+                { "AddName",            controller_method_add_name,             controller_type_in_osu,         controller_type_out_unit },
+                { "AddListener",        controller_method_add_listener,         controller_type_in_ohv,         controller_type_out_unit },
+                { "AddMetrics",         controller_method_add_metrics,          controller_type_in_oh,          controller_type_out_unit },
+                { "SetUserQuota",       controller_method_set_user_quota,       controller_type_in_uuuuu,       controller_type_out_unit },
         };
 
         for (size_t i = 0; i < C_ARRAY_SIZE(methods); i++) {

--- a/src/broker/controller.c
+++ b/src/broker/controller.c
@@ -425,6 +425,32 @@ int controller_add_metrics(Controller *controller,
 }
 
 /**
+ * controller_set_user_quota() - set per-UID quota overrides
+ * @controller:         controller to operate on
+ * @uid:                uid of user to set limits for
+ * @max_bytes:          maximum bytes quota for the user
+ * @max_fds:            maximum file descriptors quota for the user
+ * @max_matches:        maximum match rules quota for the user
+ * @max_objects:        maximum objects quota for the user
+ *
+ * This sets per-UID quota overrides for the specified user. The new limits
+ * apply immediately if the user already exists, and are used when the user
+ * first connects if they do not yet exist.
+ *
+ * Return: 0 on success, error code on failure.
+ */
+int controller_set_user_quota(Controller *controller,
+                              uid_t uid,
+                              unsigned int max_bytes,
+                              unsigned int max_fds,
+                              unsigned int max_matches,
+                              unsigned int max_objects) {
+        unsigned int maxima[] = { max_bytes, max_fds, max_matches, max_objects };
+
+        return error_fold(user_registry_set_user_limits(&controller->broker->bus.users, uid, maxima));
+}
+
+/**
  * controller_request_reload() - XXX
  */
 int controller_request_reload(Controller *controller,

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -174,6 +174,12 @@ int controller_add_metrics(Controller *controller,
                            ControllerMetrics **metricsp,
                            const char *path,
                            int metrics_fd);
+int controller_set_user_quota(Controller *controller,
+                              uid_t uid,
+                              unsigned int max_bytes,
+                              unsigned int max_fds,
+                              unsigned int max_matches,
+                              unsigned int max_objects);
 int controller_request_reload(Controller *controller,
                               User *user,
                               uint64_t sender_id,

--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -428,6 +428,50 @@ static int config_parser_attrs_apparmor(ConfigState *state, ConfigNode *node, co
         return 0;
 }
 
+static int config_parser_attrs_user_quota(ConfigState *state, ConfigNode *node, const XML_Char **attrs) {
+        const char *k, *v;
+        int r;
+
+        while (*attrs) {
+                k = *(attrs++);
+                v = *(attrs++);
+
+                if (!strcmp(k, "user")) {
+                        r = nss_cache_get_uid(state->nss, &node->user_quota.uid, NULL, v);
+                        if (r) {
+                                if (r == NSS_CACHE_E_INVALID_NAME) {
+                                        CONFIG_ERR(state, "Invalid user-name", ": %s=\"%s\"", k, v);
+                                        node->user_quota.uid_valid = false;
+                                } else {
+                                        return error_fold(r);
+                                }
+                        } else {
+                                node->user_quota.uid_valid = true;
+                        }
+                } else if (!strcmp(k, "max_bytes")) {
+                        r = util_strtou64(&node->user_quota.max_bytes, v);
+                        if (r)
+                                CONFIG_ERR(state, "Invalid value", ": %s=\"%s\"", k, v);
+                } else if (!strcmp(k, "max_fds")) {
+                        r = util_strtou64(&node->user_quota.max_fds, v);
+                        if (r)
+                                CONFIG_ERR(state, "Invalid value", ": %s=\"%s\"", k, v);
+                } else if (!strcmp(k, "max_matches")) {
+                        r = util_strtou64(&node->user_quota.max_matches, v);
+                        if (r)
+                                CONFIG_ERR(state, "Invalid value", ": %s=\"%s\"", k, v);
+                } else if (!strcmp(k, "max_objects")) {
+                        r = util_strtou64(&node->user_quota.max_objects, v);
+                        if (r)
+                                CONFIG_ERR(state, "Invalid value", ": %s=\"%s\"", k, v);
+                } else {
+                        CONFIG_ERR(state, "Unknown attribute", ": %s=\"%s\"", k, v);
+                }
+        }
+
+        return 0;
+}
+
 static int config_parser_attrs_allow_deny(ConfigState *state, ConfigNode *node, const XML_Char **attrs) {
         const char *k, *v;
         char *t;
@@ -943,6 +987,19 @@ static void config_parser_begin_fn(void *userdata, const XML_Char *name, const X
                 if (r)
                         goto failed;
 
+        } else if (!strcmp(name, "user_quota")) {
+
+                if (state->current->type != CONFIG_NODE_BUSCONFIG)
+                        goto failed;
+
+                r = config_node_new(&node, state->current, CONFIG_NODE_USER_QUOTA);
+                if (r)
+                        goto failed;
+
+                r = config_parser_attrs_user_quota(state, node, attrs);
+                if (r)
+                        goto failed;
+
         } else if (!strcmp(name, "allow")) {
 
                 if (state->current->type != CONFIG_NODE_POLICY)
@@ -1186,6 +1243,7 @@ static void config_parser_end_fn(void *userdata, const XML_Char *name) {
         case CONFIG_NODE_ALLOW:
         case CONFIG_NODE_DENY:
         case CONFIG_NODE_ASSOCIATE:
+        case CONFIG_NODE_USER_QUOTA:
                 /* fallthrough */
         default:
                 if (state->current->cdata &&

--- a/src/launch/config.h
+++ b/src/launch/config.h
@@ -51,6 +51,7 @@ enum {
         CONFIG_NODE_ALLOW,
         CONFIG_NODE_DENY,
         CONFIG_NODE_ASSOCIATE,
+        CONFIG_NODE_USER_QUOTA,
 
         _CONFIG_NODE_N,
 };
@@ -165,6 +166,15 @@ struct ConfigNode {
                 struct {
                         unsigned int mode;
                 } apparmor;
+
+                struct {
+                        uint32_t uid;
+                        bool uid_valid : 1;
+                        uint64_t max_bytes;
+                        uint64_t max_fds;
+                        uint64_t max_matches;
+                        uint64_t max_objects;
+                } user_quota;
 
                 struct {
                         char *send_interface;

--- a/src/launch/launcher.c
+++ b/src/launch/launcher.c
@@ -1214,6 +1214,45 @@ static int launcher_set_policy(Launcher *launcher, Policy *policy, uint32_t *sys
         return 0;
 }
 
+static int launcher_set_user_quotas(Launcher *launcher, ConfigRoot *root) {
+        ConfigNode *cnode;
+        int r;
+
+        c_list_for_each_entry(cnode, &root->node_list, root_link) {
+                _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+
+                if (cnode->type != CONFIG_NODE_USER_QUOTA)
+                        continue;
+
+                if (!cnode->user_quota.uid_valid)
+                        continue;
+
+                r = sd_bus_message_new_method_call(launcher->bus_controller,
+                                                   &m,
+                                                   NULL,
+                                                   "/org/bus1/DBus/Broker",
+                                                   "org.bus1.DBus.Broker",
+                                                   "SetUserQuota");
+                if (r < 0)
+                        return error_origin(r);
+
+                r = sd_bus_message_append(m, "uuuuu",
+                                          cnode->user_quota.uid,
+                                          util_t2u_saturating(cnode->user_quota.max_bytes),
+                                          util_t2u_saturating(cnode->user_quota.max_fds),
+                                          util_t2u_saturating(cnode->user_quota.max_matches),
+                                          util_t2u_saturating(cnode->user_quota.max_objects));
+                if (r < 0)
+                        return error_origin(r);
+
+                r = sd_bus_call(launcher->bus_controller, m, 0, NULL, NULL);
+                if (r < 0)
+                        return error_origin(r);
+        }
+
+        return 0;
+}
+
 static int launcher_apparmor_apply(unsigned int *apparmor_mode) {
         bool enabled, supported;
         int r;
@@ -1305,6 +1344,10 @@ static int launcher_reload_config(Launcher *launcher) {
                 goto out;
 
         r = launcher_set_policy(launcher, &policy, system_console_users, n_system_console_users);
+        if (r)
+                goto out;
+
+        r = launcher_set_user_quotas(launcher, root);
         if (r)
                 goto out;
 
@@ -1470,6 +1513,10 @@ int launcher_run(Launcher *launcher) {
                 return error_trace(r);
 
         r = launcher_add_listener(launcher, &policy, system_console_users, n_system_console_users);
+        if (r)
+                return error_trace(r);
+
+        r = launcher_set_user_quotas(launcher, root);
         if (r)
                 return error_trace(r);
 

--- a/src/launch/test-config.c
+++ b/src/launch/test-config.c
@@ -34,6 +34,7 @@ static const char *test_type2str[_CONFIG_NODE_N] = {
         [CONFIG_NODE_ALLOW]             = "allow",
         [CONFIG_NODE_DENY]              = "deny",
         [CONFIG_NODE_ASSOCIATE]         = "associate",
+        [CONFIG_NODE_USER_QUOTA]        = "user_quota",
 };
 
 static int config_memfd(const char *data) {
@@ -144,6 +145,82 @@ static void test_config_sample1(void) {
         c_assert(r == CONFIG_E_INVALID);
 }
 
+static void test_config_user_quota(void) {
+        _c_cleanup_(config_root_freep) ConfigRoot *root = NULL;
+        ConfigNode *node;
+        const char *data;
+        bool found_quota = false;
+        int r;
+
+        /* Valid user_quota element for root (uid 0, always resolvable). */
+        data =
+"<?xml version=\"1.0\"?>\
+<busconfig>\
+  <user_quota user=\"root\" max_bytes=\"10485760\" max_fds=\"256\" max_matches=\"2048\" max_objects=\"4096\"/>\
+</busconfig>";
+
+        r = parse_config_inline(&root, data);
+        c_assert(!r);
+
+        c_list_for_each_entry(node, &root->node_list, root_link) {
+                if (node->type != CONFIG_NODE_USER_QUOTA)
+                        continue;
+
+                /* root UID is always 0 and resolvable */
+                c_assert(node->user_quota.uid_valid);
+                c_assert(node->user_quota.uid == 0);
+                c_assert(node->user_quota.max_bytes == 10485760);
+                c_assert(node->user_quota.max_fds == 256);
+                c_assert(node->user_quota.max_matches == 2048);
+                c_assert(node->user_quota.max_objects == 4096);
+                found_quota = true;
+        }
+
+        c_assert(found_quota);
+        config_root_free(root);
+        root = NULL;
+
+        /* Multiple user_quota elements are all collected. */
+        data =
+"<?xml version=\"1.0\"?>\
+<busconfig>\
+  <user_quota user=\"root\" max_bytes=\"1024\" max_fds=\"16\" max_matches=\"128\" max_objects=\"256\"/>\
+  <user_quota user=\"root\" max_bytes=\"2048\" max_fds=\"32\" max_matches=\"256\" max_objects=\"512\"/>\
+</busconfig>";
+
+        r = parse_config_inline(&root, data);
+        c_assert(!r);
+
+        {
+                unsigned int n_quota = 0;
+                c_list_for_each_entry(node, &root->node_list, root_link) {
+                        if (node->type == CONFIG_NODE_USER_QUOTA)
+                                ++n_quota;
+                }
+                c_assert(n_quota == 2);
+        }
+
+        config_root_free(root);
+        root = NULL;
+
+        /* Unknown user resolves with uid_valid=false but does not fail the parse. */
+        data =
+"<?xml version=\"1.0\"?>\
+<busconfig>\
+  <user_quota user=\"no-such-user-xyz\" max_bytes=\"1024\" max_fds=\"16\" max_matches=\"128\" max_objects=\"256\"/>\
+</busconfig>";
+
+        r = parse_config_inline(&root, data);
+        c_assert(!r);
+
+        c_list_for_each_entry(node, &root->node_list, root_link) {
+                if (node->type != CONFIG_NODE_USER_QUOTA)
+                        continue;
+
+                c_assert(!node->user_quota.uid_valid);
+        }
+}
+
 int main(int argc, char **argv) {
         if (argc > 1) {
                 print_config(argv[1]);
@@ -153,6 +230,7 @@ int main(int argc, char **argv) {
         test_config_base();
         test_config_sample0();
         test_config_sample1();
+        test_config_user_quota();
 
         return 0;
 }

--- a/src/util/test-user.c
+++ b/src/util/test-user.c
@@ -128,9 +128,96 @@ static void test_overflow(void) {
         user_registry_deinit(&registry);
 }
 
+static void test_per_uid_quota(void) {
+        UserRegistry registry;
+        User *entry1, *entry2;
+        UserCharge charge2;
+        int r;
+
+        r = user_registry_init(&registry, NULL, _USER_SLOT_N, (unsigned int[]){ 1024, 1024, 1024, 1024 });
+        c_assert(!r);
+
+        /*
+         * Test 1: Override applied before user is created.
+         * Set a higher quota for uid 1, then create the user and verify it
+         * gets the higher limit.
+         */
+        r = user_registry_set_user_limits(&registry, 1, (unsigned int[]){ 2048, 2048, 2048, 2048 });
+        c_assert(!r);
+
+        r = user_registry_ref_user(&registry, &entry1, 1);
+        c_assert(!r);
+
+        /* uid 1 should have max 2048, not the global 1024 */
+        c_assert(entry1->slots[USER_SLOT_BYTES].max == 2048);
+        c_assert(entry1->slots[USER_SLOT_BYTES].n == 2048);
+
+        user_unref(entry1);
+
+        /*
+         * Test 2: Override applied to an already-existing user.
+         * Create a user, consume some resources, then update its quota.
+         */
+        r = user_registry_ref_user(&registry, &entry2, 2);
+        c_assert(!r);
+
+        /* uid 2 gets default quota */
+        c_assert(entry2->slots[USER_SLOT_BYTES].max == 1024);
+
+        /* consume 200 bytes */
+        user_charge_init(&charge2);
+        r = user_charge(entry2, &charge2, NULL, USER_SLOT_BYTES, 200);
+        c_assert(!r);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 824);
+
+        /* increase quota to 2048 while user is active */
+        r = user_registry_set_user_limits(&registry, 2, (unsigned int[]){ 2048, 2048, 2048, 2048 });
+        c_assert(!r);
+
+        /* remaining should be adjusted: 2048 - 200 consumed = 1848 */
+        c_assert(entry2->slots[USER_SLOT_BYTES].max == 2048);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 1848);
+
+        /* release the charge: n should return to new max */
+        user_charge_deinit(&charge2);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 2048);
+
+        /*
+         * Test 3: Decreasing quota below consumed amount clamps to consumed.
+         */
+        user_charge_init(&charge2);
+        r = user_charge(entry2, &charge2, NULL, USER_SLOT_BYTES, 500);
+        c_assert(!r);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 1548);
+
+        /* try to lower quota to 300, but 500 is already consumed: clamp to 500 */
+        r = user_registry_set_user_limits(&registry, 2, (unsigned int[]){ 300, 300, 300, 300 });
+        c_assert(!r);
+        c_assert(entry2->slots[USER_SLOT_BYTES].max == 500);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 0);
+
+        /* release charge: n returns to clamped max */
+        user_charge_deinit(&charge2);
+        c_assert(entry2->slots[USER_SLOT_BYTES].n == 500);
+        c_assert(entry2->slots[USER_SLOT_BYTES].max == 500);
+
+        user_unref(entry2);
+
+        /*
+         * Test 4: When uid 1 (with override) is created again, override persists.
+         */
+        r = user_registry_ref_user(&registry, &entry1, 1);
+        c_assert(!r);
+        c_assert(entry1->slots[USER_SLOT_BYTES].max == 2048);
+        user_unref(entry1);
+
+        user_registry_deinit(&registry);
+}
+
 int main(int argc, char **argv) {
         test_setup();
         test_quota();
         test_overflow();
+        test_per_uid_quota();
         return 0;
 }

--- a/src/util/user.c
+++ b/src/util/user.c
@@ -82,6 +82,27 @@ static UserUsage *user_usage_unref(UserUsage *usage) {
 
 C_DEFINE_CLEANUP(UserUsage *, user_usage_unref);
 
+static int user_override_compare(CRBTree *tree, void *k, CRBNode *rb) {
+        UserQuotaOverride *override = c_container_of(rb, UserQuotaOverride, registry_node);
+        uid_t uid = *(uid_t *)k;
+
+        if (uid < override->uid)
+                return -1;
+        if (uid > override->uid)
+                return 1;
+
+        return 0;
+}
+
+static UserQuotaOverride *user_registry_find_override(UserRegistry *registry, uid_t uid) {
+        CRBNode *node = c_rbtree_find_node(&registry->override_tree, user_override_compare, &uid);
+
+        if (!node)
+                return NULL;
+
+        return c_container_of(node, UserQuotaOverride, registry_node);
+}
+
 static int user_usage_compare(CRBTree *tree, void *k, CRBNode *rb) {
         UserUsage *usage = c_container_of(rb, UserUsage, user_node);
         uid_t uid = *(uid_t*)k;
@@ -167,6 +188,7 @@ static void user_unlink(User *user) {
 }
 
 static int user_new(User **userp, UserRegistry *registry, uid_t uid) {
+        UserQuotaOverride *override;
         User *user;
         size_t i;
 
@@ -180,8 +202,9 @@ static int user_new(User **userp, UserRegistry *registry, uid_t uid) {
         user->registry_node = (CRBNode)C_RBNODE_INIT(user->registry_node);
         user->usage_tree = (CRBTree)C_RBTREE_INIT;
 
+        override = user_registry_find_override(registry, uid);
         for (i = 0; i < registry->n_slots; ++i) {
-                user->slots[i].max = registry->maxima[i];
+                user->slots[i].max = override ? override->maxima[i] : registry->maxima[i];
                 user->slots[i].n = user->slots[i].max;
         }
 
@@ -403,7 +426,12 @@ int user_registry_init(UserRegistry *registry,
  * have been destroyed before the registry is deinitialized.
  */
 void user_registry_deinit(UserRegistry *registry) {
+        UserQuotaOverride *override, *override_safe;
+
         c_assert(c_rbtree_is_empty(&registry->user_tree));
+
+        c_rbtree_for_each_entry_safe_postorder_unlink(override, override_safe, &registry->override_tree, registry_node)
+                free(override);
 
         free(registry->maxima);
         *registry = (UserRegistry)USER_REGISTRY_NULL;
@@ -438,5 +466,72 @@ int user_registry_ref_user(UserRegistry *registry, User **userp, uid_t uid) {
         }
 
         *userp = user;
+        return 0;
+}
+
+/**
+ * user_registry_set_user_limits() - set per-UID quota overrides
+ * @registry:           registry to operate on
+ * @uid:                uid of user to set limits for
+ * @maxima:             new maxima for each accounting slot
+ *
+ * This stores per-UID quota overrides in the registry. The override is applied
+ * when a new user object is created for @uid. If a user object for @uid already
+ * exists, its limits are updated immediately: the remaining quota is adjusted
+ * by the same delta as the maximum, preserving any resources already consumed.
+ * If the new maximum is less than the amount already consumed, the maximum is
+ * clamped to the consumed amount so the accounting invariant is maintained.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int user_registry_set_user_limits(UserRegistry *registry, uid_t uid, const unsigned int *maxima) {
+        UserQuotaOverride *override;
+        CRBNode **slot, *parent;
+        User *user;
+        size_t i;
+
+        slot = c_rbtree_find_slot(&registry->override_tree, user_override_compare, &uid, &parent);
+        if (slot) {
+                override = calloc(1, sizeof(*override) + registry->n_slots * sizeof(*override->maxima));
+                if (!override)
+                        return error_origin(-ENOMEM);
+
+                override->uid = uid;
+                override->registry_node = (CRBNode)C_RBNODE_INIT(override->registry_node);
+                c_rbtree_add(&registry->override_tree, parent, slot, &override->registry_node);
+        } else {
+                override = c_container_of(parent, UserQuotaOverride, registry_node);
+        }
+
+        c_memcpy(override->maxima, maxima, registry->n_slots * sizeof(*override->maxima));
+
+        /* If the user already exists, update their limits immediately. */
+        {
+                CRBNode *unode = c_rbtree_find_node(&registry->user_tree, user_compare, &uid);
+
+                if (unode) {
+                        user = c_container_of(unode, User, registry_node);
+
+                        for (i = 0; i < registry->n_slots; ++i) {
+                                unsigned int old_max = user->slots[i].max;
+                                unsigned int old_n = user->slots[i].n;
+                                unsigned int consumed = old_max - old_n;
+                                unsigned int new_max = maxima[i];
+
+                                /*
+                                 * Clamp new_max to consumed to maintain the
+                                 * invariant that n == max when all resources
+                                 * are released (i.e., n == max - consumed
+                                 * once all charges are freed).
+                                 */
+                                if (new_max < consumed)
+                                        new_max = consumed;
+
+                                user->slots[i].max = new_max;
+                                user->slots[i].n = new_max - consumed;
+                        }
+                }
+        }
+
         return 0;
 }

--- a/src/util/user.h
+++ b/src/util/user.h
@@ -14,6 +14,7 @@ typedef struct Log Log;
 typedef struct UserCharge UserCharge;
 typedef struct UserUsage UserUsage;
 typedef struct User User;
+typedef struct UserQuotaOverride UserQuotaOverride;
 typedef struct UserRegistry UserRegistry;
 
 /* XXX: move this to some global broker header file */
@@ -93,22 +94,33 @@ struct User {
 void user_free(_Atomic unsigned long *n_refs, void *userdata);
 int user_charge(User *user, UserCharge *charge, User *actor, size_t slot, unsigned int amount);
 
+/* quota override */
+
+struct UserQuotaOverride {
+        uid_t uid;
+        CRBNode registry_node;
+        unsigned int maxima[];
+};
+
 /* registry */
 
 struct UserRegistry {
         Log *log;
         CRBTree user_tree;
+        CRBTree override_tree;
         size_t n_slots;
         unsigned int *maxima;
 };
 
 #define USER_REGISTRY_NULL {                                                    \
                 .user_tree = C_RBTREE_INIT,                                     \
+                .override_tree = C_RBTREE_INIT,                                 \
         }
 
 int user_registry_init(UserRegistry *registry, Log *log, size_t n_slots, const unsigned int *maxima);
 void user_registry_deinit(UserRegistry *registry);
 int user_registry_ref_user(UserRegistry *registry, User **userp, uid_t uid);
+int user_registry_set_user_limits(UserRegistry *registry, uid_t uid, const unsigned int *maxima);
 
 /* inline helpers */
 


### PR DESCRIPTION
Put up a POC way of potentially implementing per unix UID quotas.

- [x] Implement `SetUserQuota` controller method and `user_registry_set_user_limits()`
- [x] Register `SetUserQuota` D-Bus method in controller-dbus.c
- [x] Add `<user_quota>` XML config element parser in config.c/config.h
- [x] Add `launcher_set_user_quotas()` in launcher.c, called on startup and ReloadConfig
- [x] Add unit tests in test-user.c and test-config.c
- [x] Update `docs/dbus-broker.rst` — document new `SetUserQuota` API method
- [x] Update `docs/dbus-broker-launch.rst` — document new `<user_quota>` XML config element with example and inotify reload note

This does need testing. So all for ways on how to do that easily.

Fixes #430 