### PR TITLE
apparmor: Implement audit log fallback

### DIFF
--- a/src/broker/controller-dbus.c
+++ b/src/broker/controller-dbus.c
@@ -241,7 +241,7 @@ static int controller_method_add_listener(Controller *controller, const char *_p
         uint32_t fd_index;
         socklen_t n;
 
-        r = policy_registry_new(&policy, controller->broker->bus.seclabel);
+        r = policy_registry_new(&policy, controller->broker->log, controller->broker->bus.seclabel);
         if (r)
                 return error_fold(r);
 
@@ -399,7 +399,7 @@ static int controller_method_listener_set_policy(Controller *controller, const c
         ControllerListener *listener;
         int r;
 
-        r = policy_registry_new(&policy, controller->broker->bus.seclabel);
+        r = policy_registry_new(&policy, controller->broker->log, controller->broker->bus.seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/bus/policy.c
+++ b/src/bus/policy.c
@@ -404,7 +404,7 @@ static int policy_registry_node_new(PolicyRegistryNode **nodep, uint32_t uidgid_
 /**
  * policy_registry_new() - XXX
  */
-int policy_registry_new(PolicyRegistry **registryp, const char *fallback_seclabel) {
+int policy_registry_new(PolicyRegistry **registryp, Log *log, const char *fallback_seclabel) {
         _c_cleanup_(policy_registry_freep) PolicyRegistry *registry = NULL;
         int r;
 
@@ -414,7 +414,7 @@ int policy_registry_new(PolicyRegistry **registryp, const char *fallback_seclabe
 
         *registry = (PolicyRegistry)POLICY_REGISTRY_NULL;
 
-        r = bus_apparmor_registry_new(&registry->apparmor, fallback_seclabel);
+        r = bus_apparmor_registry_new(&registry->apparmor, log, fallback_seclabel);
         if (r)
                 return error_fold(r);
 

--- a/src/bus/policy.h
+++ b/src/bus/policy.h
@@ -14,6 +14,7 @@
 
 typedef struct BusAppArmorRegistry BusAppArmorRegistry;
 typedef struct BusSELinuxRegistry BusSELinuxRegistry;
+typedef struct Log Log;
 typedef struct NameSet NameSet;
 typedef struct PolicyBatch PolicyBatch;
 typedef struct PolicyBatchName PolicyBatchName;
@@ -145,7 +146,7 @@ void policy_batch_free(_Atomic unsigned long *n_refs, void *userdata);
 
 /* registry */
 
-int policy_registry_new(PolicyRegistry **registryp, const char *fallback_seclabel);
+int policy_registry_new(PolicyRegistry **registryp, Log *log, const char *fallback_seclabel);
 PolicyRegistry *policy_registry_free(PolicyRegistry *registry);
 
 int policy_registry_import(PolicyRegistry *registry, CDVar *v);

--- a/src/util/apparmor-fallback.c
+++ b/src/util/apparmor-fallback.c
@@ -40,7 +40,7 @@ int bus_apparmor_dbus_supported(bool *supportedp) {
         return 0;
 }
 
-int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, const char *fallback_context) {
+int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, Log *log, const char *fallback_context) {
         *registryp = NULL;
         return 0;
 }

--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -15,11 +15,13 @@
 #include "util/apparmor.h"
 #include "util/audit.h"
 #include "util/error.h"
+#include "util/log.h"
 #include "util/ref.h"
 #include "util/string.h"
 
 struct BusAppArmorRegistry {
         _Atomic unsigned long n_refs;
+        Log *log;
         char *bustype;
         char fallback_context[];
 };
@@ -105,11 +107,12 @@ int bus_apparmor_dbus_supported(bool *supportedp) {
 /**
  * bus_apparmor_registry_new() - create a new AppArmor registry
  * @registryp:          output pointer to the new registry
+ * @log:                log context to use for audit fallback messages
  * @fallback_context:   fallback security context for queries against this registry
  *
  * Return: 0 on success, or a negative error code on failure.
  */
-int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, const char *fallback_context) {
+int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, Log *log, const char *fallback_context) {
         _c_cleanup_(bus_apparmor_registry_unrefp) BusAppArmorRegistry *registry = NULL;
         size_t n_fallback_context;
 
@@ -119,6 +122,7 @@ int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, const char *fallb
                 return error_origin(-ENOMEM);
 
         registry->n_refs = REF_INIT;
+        registry->log = log;
         strcpy(registry->fallback_context, fallback_context);
 
         *registryp = registry;

--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -183,8 +183,15 @@ static int bus_apparmor_log(
                 return error_origin(-errno);
 
         r = util_audit_log(UTIL_AUDIT_TYPE_AVC, message, uid);
-        if (r != UTIL_AUDIT_E_UNAVAILABLE) // XXX: use a log fallback
+        if (r != UTIL_AUDIT_E_UNAVAILABLE)
                 return error_fold(r);
+
+        if (registry->log) {
+                log_append_here(registry->log, LOG_NOTICE, 0, NULL);
+                r = log_commitf(registry->log, "%s", message);
+                if (r)
+                        return error_fold(r);
+        }
 
         return 0;
 }

--- a/src/util/apparmor.h
+++ b/src/util/apparmor.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 typedef struct NameSet NameSet;
+typedef struct Log Log;
 
 typedef struct BusAppArmorRegistry BusAppArmorRegistry;
 
@@ -20,7 +21,7 @@ enum {
 int bus_apparmor_is_enabled(bool *enabledp);
 int bus_apparmor_dbus_supported(bool *supportedp);
 
-int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, const char *fallback_context);
+int bus_apparmor_registry_new(BusAppArmorRegistry **registryp, Log *log, const char *fallback_context);
 BusAppArmorRegistry *bus_apparmor_registry_ref(BusAppArmorRegistry *registry);
 BusAppArmorRegistry *bus_apparmor_registry_unref(BusAppArmorRegistry *registry);
 


### PR DESCRIPTION
If we're unable to send kernel audits then print the audit message to the log instead. Matches the behaviour of dbus-daemon.