### PR TITLE
bus: add a per-activation timeout to heal stuck activations

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -40,7 +40,7 @@ static int broker_dispatch_signals(DispatchFile *file) {
         return DISPATCH_E_EXIT;
 }
 
-int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects) {
+int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects, uint64_t activation_timeout_ms) {
         _c_cleanup_(broker_freep) Broker *broker = NULL;
         struct ucred ucred;
         socklen_t z;
@@ -61,6 +61,10 @@ int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controlle
         broker->dispatcher = (DispatchContext)DISPATCH_CONTEXT_NULL(broker->dispatcher);
         broker->signals_fd = -1;
         broker->signals_file = (DispatchFile)DISPATCH_FILE_NULL(broker->signals_file);
+        broker->activation_timeout_nsec = activation_timeout_ms * UINT64_C(1000000);
+        broker->pending_activations = (CList)C_LIST_INIT(broker->pending_activations);
+        broker->activation_timer_fd = -1;
+        broker->activation_timer_file = (DispatchFile)DISPATCH_FILE_NULL(broker->activation_timer_file);
         broker->controller = (Controller)CONTROLLER_NULL(broker->controller);
 
         r = bus_init(&broker->bus, broker->log, machine_id, max_bytes, max_fds, max_matches, max_objects);
@@ -131,6 +135,10 @@ int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controlle
 
         dispatch_file_select(&broker->signals_file, EPOLLIN);
 
+        r = activation_timer_init(broker);
+        if (r)
+                return error_fold(r);
+
         r = controller_init(&broker->controller, broker, controller_fd);
         if (r)
                 return error_fold(r);
@@ -147,6 +155,7 @@ Broker *broker_free(Broker *broker) {
         controller_deinit(&broker->controller);
         dispatch_file_deinit(&broker->signals_file);
         c_close(broker->signals_fd);
+        activation_timer_deinit(broker);
         dispatch_context_deinit(&broker->dispatcher);
         bus_deinit(&broker->bus);
         free(broker);

--- a/src/broker/broker.h
+++ b/src/broker/broker.h
@@ -28,12 +28,17 @@ struct Broker {
         int signals_fd;
         DispatchFile signals_file;
 
+        uint64_t activation_timeout_nsec;
+        CList pending_activations;
+        int activation_timer_fd;
+        DispatchFile activation_timer_file;
+
         Controller controller;
 };
 
 /* broker */
 
-int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects);
+int broker_new(Broker **brokerp, Log *log, const char *machine_id, int controller_fd, uint64_t max_bytes, uint64_t max_fds, uint64_t max_matches, uint64_t max_objects, uint64_t activation_timeout_ms);
 Broker *broker_free(Broker *broker);
 
 int broker_run(Broker *broker);

--- a/src/broker/controller.h
+++ b/src/broker/controller.h
@@ -69,6 +69,7 @@ enum {
         CONTROLLER_NAME_ERROR_STARTUP_FAILURE           = 6,
         CONTROLLER_NAME_ERROR_STARTUP_SKIPPED           = 7,
         CONTROLLER_NAME_ERROR_NAME_RELEASED             = 8,
+        CONTROLLER_NAME_ERROR_ACTIVATION_TIMEOUT        = 9,
         _CONTROLLER_NAME_ERROR_N,
 };
 
@@ -216,6 +217,7 @@ static const char *const controller_name_error_table[_CONTROLLER_NAME_ERROR_N] =
         [CONTROLLER_NAME_ERROR_STARTUP_FAILURE]         = "org.bus1.DBus.Name.Error.StartupFailure",
         [CONTROLLER_NAME_ERROR_STARTUP_SKIPPED]         = "org.bus1.DBus.Name.Error.StartupSkipped",
         [CONTROLLER_NAME_ERROR_NAME_RELEASED]           = "org.bus1.DBus.Name.Error.NameReleased",
+        [CONTROLLER_NAME_ERROR_ACTIVATION_TIMEOUT]      = "org.bus1.DBus.Name.Error.ActivationTimeout",
 };
 
 static const char *const controller_name_error_table_human_readable[_CONTROLLER_NAME_ERROR_N] = {
@@ -227,6 +229,7 @@ static const char *const controller_name_error_table_human_readable[_CONTROLLER_
         [CONTROLLER_NAME_ERROR_STARTUP_FAILURE]         = "startup job failed",
         [CONTROLLER_NAME_ERROR_STARTUP_SKIPPED]         = "startup job skipped",
         [CONTROLLER_NAME_ERROR_NAME_RELEASED]           = "activation request cancelled: bus name was released",
+        [CONTROLLER_NAME_ERROR_ACTIVATION_TIMEOUT]      = "activation request timed out: service did not claim its name in time",
 };
 
 static inline const char *controller_name_error_to_string(unsigned int error) {

--- a/src/broker/main.c
+++ b/src/broker/main.c
@@ -25,6 +25,7 @@ uint64_t main_arg_max_bytes = 512 * 1024 * 1024;
 uint64_t main_arg_max_fds = 128;
 uint64_t main_arg_max_matches = 16 * 1024;
 uint64_t main_arg_max_objects = 16 * 1024 * 1024;
+uint64_t main_arg_activation_timeout_ms = 25000;
 
 static void help(void) {
         printf("%s [GLOBALS...] ...\n\n"
@@ -39,6 +40,7 @@ static void help(void) {
                "     --max-fds FDS              Maximum number of file descriptors each user may allocate in the broker\n"
                "     --max-matches MATCHES      Maximum number of match rules each user may allocate in the broker\n"
                "     --max-objects OBJECTS      Maximum total number of names, peers, pending replies, etc each user may allocate in the broker\n"
+               "     --activation-timeout-ms MS Maximum time in milliseconds a name activation may stay pending before it is failed (0 disables)\n"
                , program_invocation_short_name);
 }
 
@@ -53,6 +55,7 @@ static int parse_argv(int argc, char *argv[]) {
                 ARG_MAX_FDS,
                 ARG_MAX_MATCHES,
                 ARG_MAX_OBJECTS,
+                ARG_ACTIVATION_TIMEOUT,
         };
         static const struct option options[] = {
                 { "help",               no_argument,            NULL,   'h'                     },
@@ -65,6 +68,7 @@ static int parse_argv(int argc, char *argv[]) {
                 { "max-fds",            required_argument,      NULL,   ARG_MAX_FDS             },
                 { "max-matches",        required_argument,      NULL,   ARG_MAX_MATCHES         },
                 { "max-objects",        required_argument,      NULL,   ARG_MAX_OBJECTS         },
+                { "activation-timeout-ms", required_argument,   NULL,   ARG_ACTIVATION_TIMEOUT  },
                 {}
         };
         int r, c;
@@ -154,6 +158,15 @@ static int parse_argv(int argc, char *argv[]) {
                         r = util_strtou64(&main_arg_max_objects, optarg);
                         if (r) {
                                 fprintf(stderr, "%s: invalid max number of objects -- '%s'\n", program_invocation_name, optarg);
+                                return MAIN_FAILED;
+                        }
+
+                        break;
+
+                case ARG_ACTIVATION_TIMEOUT:
+                        r = util_strtou64(&main_arg_activation_timeout_ms, optarg);
+                        if (r) {
+                                fprintf(stderr, "%s: invalid activation timeout -- '%s'\n", program_invocation_name, optarg);
                                 return MAIN_FAILED;
                         }
 
@@ -275,7 +288,7 @@ static int run(Log *log) {
         _c_cleanup_(broker_freep) Broker *broker = NULL;
         int r;
 
-        r = broker_new(&broker, log, main_arg_machine_id, main_arg_controller, main_arg_max_bytes, main_arg_max_fds, main_arg_max_matches, main_arg_max_objects);
+        r = broker_new(&broker, log, main_arg_machine_id, main_arg_controller, main_arg_max_bytes, main_arg_max_fds, main_arg_max_matches, main_arg_max_objects, main_arg_activation_timeout_ms);
         if (!r)
                 r = broker_run(broker);
 

--- a/src/bus/activation.c
+++ b/src/bus/activation.c
@@ -4,15 +4,23 @@
 
 #include <c-list.h>
 #include <c-stdaux.h>
+#include <errno.h>
 #include <stdlib.h>
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include "broker/broker.h"
 #include "broker/controller.h"
 #include "bus/activation.h"
 #include "bus/bus.h"
+#include "bus/driver.h"
 #include "bus/name.h"
 #include "bus/policy.h"
 #include "dbus/message.h"
+#include "util/dispatch.h"
 #include "util/error.h"
 #include "util/fdlist.h"
+#include "util/nsec.h"
 #include "util/user.h"
 
 ActivationRequest *activation_request_free(ActivationRequest *request) {
@@ -72,6 +80,8 @@ void activation_deinit(Activation *activation) {
         ActivationRequest *request;
         ActivationMessage *message;
 
+        activation_timeout_disarm(activation);
+
         while ((message = c_list_first_entry(&activation->activation_messages, ActivationMessage, link)))
                 activation_message_free(message);
 
@@ -112,6 +122,143 @@ void activation_get_stats_for(Activation *activation,
         *n_fdsp = n_fds;
 }
 
+static int activation_timeout_rearm(Broker *broker) {
+        struct itimerspec spec = {};
+        Activation *head;
+
+        if (broker->activation_timer_fd < 0)
+                return 0;
+
+        /*
+         * Arm the timerfd to the head (oldest/soonest) deadline, or leave the
+         * spec all-zero to disarm it when no activation is pending.
+         */
+        head = c_list_first_entry(&broker->pending_activations, Activation, timeout_link);
+        if (head) {
+                spec.it_value.tv_sec = head->deadline / UINT64_C(1000000000);
+                spec.it_value.tv_nsec = head->deadline % UINT64_C(1000000000);
+        }
+
+        if (timerfd_settime(broker->activation_timer_fd, TFD_TIMER_ABSTIME, &spec, NULL) < 0)
+                return error_origin(-errno);
+
+        return 0;
+}
+
+static int activation_timeout_dispatch(DispatchFile *file) {
+        Broker *broker = c_container_of(file, Broker, activation_timer_file);
+        Bus *bus = &broker->bus;
+        Activation *activation, *activation_safe;
+        uint64_t now, v;
+        ssize_t l;
+        int r;
+
+        c_assert(dispatch_file_events(file) == EPOLLIN);
+
+        /*
+         * The timerfd is edge-triggered, so we must drain it and clear the
+         * cached event, or the dispatcher busy-loops on the ready-list.
+         */
+        l = read(broker->activation_timer_fd, &v, sizeof(v));
+        if (l < 0) {
+                if (errno == EAGAIN) {
+                        dispatch_file_clear(file, EPOLLIN);
+                        return 0;
+                }
+
+                return error_origin(-errno);
+        }
+
+        c_assert(l == sizeof(v));
+        dispatch_file_clear(file, EPOLLIN);
+
+        now = nsec_now(CLOCK_MONOTONIC);
+
+        /*
+         * Walk the FIFO head-first and fail every activation whose deadline has
+         * passed. driver_name_activation_failed() clears `pending`, flushes the
+         * queued requests/messages (releasing their fd/byte charges and closing
+         * fds), and via the disarm hook in driver.c unlinks the node from
+         * `broker->pending_activations` and re-arms the timer to the new head.
+         * Because the timeout is constant, deadlines are sorted, so we can stop
+         * at the first entry that has not yet aged out.
+         */
+        c_list_for_each_entry_safe(activation, activation_safe, &broker->pending_activations, timeout_link) {
+                if (activation->deadline > now)
+                        break;
+
+                r = driver_name_activation_failed(bus, activation, activation->pending,
+                                                  CONTROLLER_NAME_ERROR_ACTIVATION_TIMEOUT);
+                if (r)
+                        return error_fold(r);
+        }
+
+        return 0;
+}
+
+int activation_timer_init(Broker *broker) {
+        int r;
+
+        /* a zero timeout disables the activation timeout entirely */
+        if (!broker->activation_timeout_nsec)
+                return 0;
+
+        /*
+         * A single broker-wide timerfd multiplexes all pending-activation
+         * deadlines. It is created once for the broker's lifetime and wrapped
+         * in a DispatchFile, mirroring the signalfd in broker.c. It is armed
+         * (always to the head/soonest deadline) and disarmed as activations
+         * come and go, so an idle broker never wakes up for it.
+         */
+        broker->activation_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+        if (broker->activation_timer_fd < 0)
+                return error_origin(-errno);
+
+        r = dispatch_file_init(&broker->activation_timer_file,
+                               &broker->dispatcher,
+                               activation_timeout_dispatch,
+                               broker->activation_timer_fd,
+                               EPOLLIN,
+                               0);
+        if (r)
+                return error_fold(r);
+
+        dispatch_file_select(&broker->activation_timer_file, EPOLLIN);
+        return 0;
+}
+
+void activation_timer_deinit(Broker *broker) {
+        if (broker->activation_timer_fd < 0)
+                return;
+
+        dispatch_file_deinit(&broker->activation_timer_file);
+        broker->activation_timer_fd = c_close(broker->activation_timer_fd);
+}
+
+static int activation_timeout_arm(Activation *activation) {
+        Broker *broker = BROKER(activation->bus);
+
+        /* timeout disabled: no timerfd was created, nothing to arm */
+        if (broker->activation_timer_fd < 0)
+                return 0;
+
+        /*
+         * Append to the tail. The timeout is constant, so append order ==
+         * deadline order: the head is always the oldest/soonest to expire.
+         */
+        activation->deadline = nsec_now(CLOCK_MONOTONIC) + broker->activation_timeout_nsec;
+        c_list_link_tail(&broker->pending_activations, &activation->timeout_link);
+        return activation_timeout_rearm(broker);
+}
+
+int activation_timeout_disarm(Activation *activation) {
+        if (!c_list_is_linked(&activation->timeout_link))
+                return 0;
+
+        c_list_unlink(&activation->timeout_link);
+        return activation_timeout_rearm(BROKER(activation->bus));
+}
+
 static int activation_request(Activation *activation) {
         int r;
 
@@ -124,6 +271,11 @@ static int activation_request(Activation *activation) {
                 return error_fold(r);
 
         activation->pending = activation->bus->activation_ids;
+
+        r = activation_timeout_arm(activation);
+        if (r)
+                return error_trace(r);
+
         return 0;
 }
 

--- a/src/bus/activation.h
+++ b/src/bus/activation.h
@@ -13,6 +13,7 @@
 typedef struct Activation Activation;
 typedef struct ActivationMessage ActivationMessage;
 typedef struct ActivationRequest ActivationRequest;
+typedef struct Broker Broker;
 typedef struct Bus Bus;
 typedef struct Message Message;
 typedef struct Name Name;
@@ -50,11 +51,14 @@ struct Activation {
         CList activation_messages;
         CList activation_requests;
         uint64_t pending;
+        CList timeout_link;
+        uint64_t deadline;
 };
 
 #define ACTIVATION_NULL(_x) {                                                   \
                 .activation_messages = C_LIST_INIT((_x).activation_messages),   \
                 .activation_requests = C_LIST_INIT((_x).activation_requests),   \
+                .timeout_link = C_LIST_INIT((_x).timeout_link),                 \
         }
 
 /* requests */
@@ -69,6 +73,10 @@ ActivationMessage *activation_message_free(ActivationMessage *message);
 
 int activation_init(Activation *activation, Bus *bus, Name *name, User *user);
 void activation_deinit(Activation *activation);
+
+int activation_timer_init(Broker *broker);
+void activation_timer_deinit(Broker *broker);
+int activation_timeout_disarm(Activation *activation);
 
 void activation_get_stats_for(Activation *activation,
                               uint64_t owner_id,

--- a/src/bus/driver.c
+++ b/src/bus/driver.c
@@ -784,6 +784,9 @@ int driver_name_activation_failed(Bus *bus, Activation *activation, uint64_t ser
                 return error_origin(-errno);
 
         activation->pending = 0;
+        r = activation_timeout_disarm(activation);
+        if (r)
+                return error_trace(r);
 
         c_list_for_each_entry_safe(request, request_safe, &activation->activation_requests, link) {
                 Peer *sender;
@@ -824,6 +827,9 @@ static int driver_name_activated(Activation *activation, Peer *receiver) {
 
         /* in case the name is dropped again in the future, we should request it again */
         activation->pending = 0;
+        r = activation_timeout_disarm(activation);
+        if (r)
+                return error_trace(r);
 
         c_list_for_each_entry_safe(request, request_safe, &activation->activation_requests, link) {
                 Peer *sender;

--- a/test/dbus/test-driver.c
+++ b/test/dbus/test-driver.c
@@ -4,6 +4,7 @@
 
 #undef NDEBUG
 #include <c-stdaux.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include "dbus/protocol.h"
 #include "util/proc.h"
@@ -889,6 +890,65 @@ static void test_start_service_by_name(void) {
                                        "su", "org", 0);
                 c_assert(r < 0);
                 c_assert(!strcmp(error.name, "org.freedesktop.DBus.Error.ServiceUnknown"));
+        }
+
+        util_broker_terminate(broker);
+}
+
+static void test_activation_timeout(void) {
+        _c_cleanup_(util_broker_freep) Broker *broker = NULL;
+        int r;
+
+        /*
+         * This test drives the broker's controller stub to register an
+         * activatable name and deliberately never answers its `Activate`
+         * signal. The reference dbus-daemon(1) has no such name, so skip it
+         * when running against the reference implementation.
+         */
+        if (util_is_reference())
+                return;
+
+        util_broker_new(&broker);
+        broker->activatable = true;
+        util_broker_spawn(broker);
+
+        /*
+         * Send an fd-bearing message to an activatable name whose activation
+         * never completes (the controller stub ignores the `Activate` signal).
+         * The message is queued on the pending activation, charging the
+         * activatable user's USER_SLOT_FDS. Once --activation-timeout elapses,
+         * the broker must fail the activation and flush the queued message,
+         * replying with NameHasNoOwner (and releasing the fd charge).
+         */
+        {
+                _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
+                _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *m = NULL;
+                _c_cleanup_(sd_bus_error_free) sd_bus_error error = SD_BUS_ERROR_NULL;
+                _c_cleanup_(c_closep) int fd = -1;
+
+                util_broker_connect(broker, &bus);
+
+                fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+                c_assert(fd >= 0);
+
+                r = sd_bus_message_new_method_call(bus,
+                                                   &m,
+                                                   UTIL_BROKER_ACTIVATABLE_NAME,
+                                                   "/com/example/activatable",
+                                                   "com.example.Activatable",
+                                                   "Foo");
+                c_assert(r >= 0);
+
+                r = sd_bus_message_append(m, "h", fd);
+                c_assert(r >= 0);
+
+                /*
+                 * Blocks until the broker fails the stuck activation after the
+                 * timeout and replies with an error.
+                 */
+                r = sd_bus_call(bus, m, -1, &error, NULL);
+                c_assert(r < 0);
+                c_assert(!strcmp(error.name, "org.freedesktop.DBus.Error.NameHasNoOwner"));
         }
 
         util_broker_terminate(broker);
@@ -2622,6 +2682,7 @@ int main(int argc, char **argv) {
         test_get_name_owner();
         test_name_has_owner();
         test_start_service_by_name();
+        test_activation_timeout();
         test_update_activation_environment();
         test_list_names();
         test_list_activatable_names();

--- a/test/dbus/util-broker.c
+++ b/test/dbus/util-broker.c
@@ -183,7 +183,7 @@ const sd_bus_vtable util_vtable[] = {
         SD_BUS_VTABLE_END
 };
 
-void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp) {
+void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp, bool activatable) {
         _c_cleanup_(sd_bus_flush_close_unrefp) sd_bus *bus = NULL;
         _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message = NULL;
         _c_cleanup_(c_freep) char *fdstr = NULL;
@@ -216,6 +216,7 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
                           "--max-matches", "1000000",
                           "--max-objects", "1000000",
                           "--max-bytes", "1000000000",
+                          "--activation-timeout-ms", "500",
                           (char *)NULL);
                 /* execl(2) only returns on error */
                 c_assert(r >= 0);
@@ -264,6 +265,34 @@ void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pi
 
         r = sd_bus_call(bus, message, -1, NULL, NULL);
         c_assert(r >= 0);
+
+        /*
+         * Optionally register an activatable name. The controller stub never
+         * answers the resulting `Activate` signal, so any message sent to this
+         * name stays a pending activation forever -- exactly the scenario the
+         * activation-timeout regression test needs.
+         */
+        if (activatable) {
+                _c_cleanup_(sd_bus_message_unrefp) sd_bus_message *message2 = NULL;
+
+                r = sd_bus_message_new_method_call(bus,
+                                                   &message2,
+                                                   NULL,
+                                                   "/org/bus1/DBus/Broker",
+                                                   "org.bus1.DBus.Broker",
+                                                   "AddName");
+                c_assert(r >= 0);
+
+                r = sd_bus_message_append(message2,
+                                          "osu",
+                                          "/org/bus1/DBus/Name/0",
+                                          UTIL_BROKER_ACTIVATABLE_NAME,
+                                          (uint32_t)0);
+                c_assert(r >= 0);
+
+                r = sd_bus_call(bus, message2, -1, NULL, NULL);
+                c_assert(r >= 0);
+        }
 
         *busp = bus;
         bus = NULL;
@@ -394,7 +423,7 @@ static void *util_broker_thread(void *userdata) {
         c_assert(r >= 0);
 
         if (broker->listener_fd >= 0) {
-                util_fork_broker(&bus, event, broker->listener_fd, &broker->child_pid);
+                util_fork_broker(&bus, event, broker->listener_fd, &broker->child_pid, broker->activatable);
                 /* dbus-broker reports its controller in GetConnectionUnixProcessID */
                 broker->pid = getpid();
                 broker->listener_fd = c_close(broker->listener_fd);

--- a/test/dbus/util-broker.h
+++ b/test/dbus/util-broker.h
@@ -16,6 +16,9 @@
 
 typedef struct Broker Broker;
 
+/* well-known name the controller stub registers as activatable when requested */
+#define UTIL_BROKER_ACTIVATABLE_NAME "com.example.activatable"
+
 struct Broker {
         pthread_t thread;
         struct sockaddr_un address;
@@ -24,6 +27,7 @@ struct Broker {
         int pipe_fds[2];
         pid_t pid;
         pid_t child_pid;
+        bool activatable;
 };
 
 #define BROKER_NULL {                                                           \
@@ -38,7 +42,7 @@ struct Broker {
 
 bool util_is_reference(void);
 void util_event_new(sd_event **eventp);
-void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp);
+void util_fork_broker(sd_bus **busp, sd_event *event, int listener_fd, pid_t *pidp, bool activatable);
 void util_fork_daemon(sd_event *event, int pipe_fd, pid_t *pidp);
 
 /* broker */


### PR DESCRIPTION
### Background
We observed production hosts where dbus-broker stopped accepting new connections entirely: clients (including systemd) lost the bus, new logins failed, and the only recovery was systemctl restart dbus-broker.

### Root cause
The trigger is a D-Bus activation that never completes. When a message is sent to an activatable name with no current owner, the broker queues it and asks the controller (launcher → systemd) to start the unit. The queued messages — and the file descriptors they carry — are charged to the activatable service's user.

If the unit starts but never claims the name (or never starts), nothing ever drains that queue. Pending messages and their passed fds accumulate without bound against that user's quota. For a root-owned activatable name this is fatal: once root's fd quota is exhausted, the broker refuses new root connections (each connection self-charges an fd). At that point the very service that needs to connect to claim the name can no longer connect — so the activation can never complete, and the queue can never drain. It's a self-locking deadlock.

### Two factors make this unrecoverable on its own:

The broker core has no timeout on a pending activation — it relies entirely on the controller to report success or failure, and the launcher only forwards failures, never "unit started but never claimed the name."
The per-user quota is shared, and because these are effectively self-charges the per-actor fairness sub-quota is skipped, so a single stuck activation can consume the user's entire fd budget.

### Fix
Add a configurable activation timeout to the broker core. A pending activation that does not complete within the timeout is failed, which flushes its queued requests/messages (sending the appropriate error replies and releasing their fd/byte charges). This bounds resource use in time and heals the deadlock — once the fds are released, the service can connect again and the next activation succeeds. This mirrors the long-standing service-start-timeout in dbus-daemon.

### Implementation notes:
* A single broker-wide timerfd multiplexes all pending-activation deadlines — deliberately not one fd per activation, since the whole point is to fix an fd-exhaustion problem. It adds exactly one fd to the broker for its entire lifetime.
* Pending activations are tracked in a deadline-ordered FIFO. Because the timeout is constant, insertion order equals deadline order, so a plain list suffices (head = soonest to expire) — no heap.
* The timerfd is armed to the head's deadline (TFD_TIMER_ABSTIME) and disarmed when no activation is pending, so an idle broker never wakes up for it.
* On expiry the broker walks the FIFO head-first and fails only the aged-out activations, reusing the existing activation-failure flush path.

### Configuration
New --activation-timeout=<ms> CLI argument, default 25000 (matching dbus-daemon); 0 disables the timeout. The launcher is unchanged in this round; the broker default applies.

## Behavior change
A message to a non-starting activatable service now receives org.freedesktop.DBus.Error.NameHasNoOwner after the timeout instead of hanging indefinitely — consistent with dbus-daemon.

### Testing
New regression test (test-driver): registers an activatable name whose activation never completes, sends an fd-bearing message to it, and asserts the sender receives NameHasNoOwner after the timeout — confirming the queued message is flushed and its fd charge released.
Existing broker test suite passes; the new test is skipped against the reference dbus-daemon.