### PR TITLE
util/apparmor: annotate bus_apparmor_log() as printf-like and fix bin…

### DIFF
--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -166,7 +166,7 @@ int bus_apparmor_set_bus_type(BusAppArmorRegistry *registry, const char *bustype
         return 0;
 }
 
-static int bus_apparmor_log(
+static int _c_printf_(3, 4) bus_apparmor_log(
         BusAppArmorRegistry *registry,
         uid_t uid,
         const char *fmt,
@@ -425,7 +425,7 @@ int bus_apparmor_check_own(
                         " operation=\"dbus_bind\""
                         " bus=\"%s\""
                         " name=\"%s\""
-                        " mask=\"bind\"",
+                        " mask=\"bind\""
                         " label=\"%s\"",
                         allow ? "ALLOWED" : "DENIED",
                         registry->bustype,


### PR DESCRIPTION
bus_apparmor_log() is a printf-style wrapper with no format attribute, so
its callers were never checked. That hid a bug: a stray comma in
bus_apparmor_check_own() split the format string, so the audit record for
RequestName decisions dropped the requested name and the confining label
and shifted the other fields:

    before:  apparmor=" label="%s"" operation="dbus_bind" bus="DENIED" name="system" mask="bind"
    after:   apparmor="DENIED" operation="dbus_bind" bus="system" name="com.example.Service" mask="bind" label="foo//bar"

The send/receive/eavesdrop blocks do the same thing correctly, so this was
the only one off. I added _c_printf_() to the helper so the compiler catches
this from now on, and joined the fragments so the four %s match their args.
This path only runs as root with the AppArmor LSM loaded, so there's no unit
test, but the attribute gives the same check at build time.
