### PR TITLE
util/sockopt: fix peer group deduplication

### DIFF
--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -121,6 +121,7 @@ int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t primary_gid, gid_t
                                 if (gids[i] != gids[j])
                                         gids[++j] = gids[i];
                         }
+                        n_gids = j + 1;
 
                         if (gidsp) {
                                 *gidsp = gids;


### PR DESCRIPTION
While reading through `sockopt_get_peergroups()` I noticed the peer group
list is never actually deduplicated. After `SO_PEERGROUPS`, the list is
sorted and the dedup loop compacts the unique entries to the front, but
`n_gids` is never updated, so the original (pre-dedup) count is returned.
A duplicate GID is left at the tail and the count is too large.

It's easy to hit, since the primary GID at `gids[0]` is often also one of
the supplementary groups, e.g. `[3, 5, 7]` with primary GID `5`:

