### PR TITLE
sockopt: prevent authorization bypass via duplicate GIDs

### DIFF
--- a/src/util/sockopt.c
+++ b/src/util/sockopt.c
@@ -69,10 +69,25 @@ static int gid_compare(const void *va, const void *vb) {
                 return 0;
 }
 
+size_t sockopt_sort_unique_gids(gid_t *gids, size_t n_gids) {
+        size_t i, unique;
+
+        if (!n_gids)
+                return 0;
+
+        qsort(gids, n_gids, sizeof(*gids), gid_compare);
+        unique = 1;
+        for (i = 1; i < n_gids; ++i)
+                if (gids[i] != gids[unique - 1])
+                        gids[unique++] = gids[i];
+
+        return unique;
+}
+
 int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t primary_gid, gid_t **gidsp, size_t *n_gidsp) {
         _c_cleanup_(c_freep) gid_t *gids = NULL;
         socklen_t socklen;
-        int r, n_gids, i, j;
+        int r, n_gids;
         void *tmp;
 
         /*
@@ -113,13 +128,13 @@ int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t primary_gid, gid_t
                 if (r < 0 && errno != ENOPROTOOPT) {
                         return error_origin(-errno);
                 } else if (r >= 0) {
-                        n_gids = 1 + socklen / sizeof(*gids);
+                        size_t n_alloc = 1 + socklen / sizeof(*gids);
+                        n_gids = (int)sockopt_sort_unique_gids(gids, n_alloc);
 
-                        /* Sort and deduplicate for deterministic behavior. */
-                        qsort(gids, n_gids, sizeof(*gids), gid_compare);
-                        for (i = 1, j = 0; i < n_gids; ++i) {
-                                if (gids[i] != gids[j])
-                                        gids[++j] = gids[i];
+                        if ((size_t)n_gids < n_alloc) {
+                                tmp = realloc(gids, (size_t)n_gids * sizeof(*gids));
+                                if (tmp)
+                                        gids = tmp;
                         }
 
                         if (gidsp) {

--- a/src/util/sockopt.h
+++ b/src/util/sockopt.h
@@ -19,4 +19,5 @@ typedef struct Log Log;
 
 int sockopt_get_peersec(int fd, char **labelp, size_t *lenp);
 int sockopt_get_peergroups(int fd, Log *log, uid_t uid, gid_t primary_gid, gid_t **gidsp, size_t *n_gidsp);
+size_t sockopt_sort_unique_gids(gid_t *gids, size_t n_gids);
 int sockopt_get_peerpidfd(int fd, int *ret_pidfd);

--- a/src/util/test-sockopt.c
+++ b/src/util/test-sockopt.c
@@ -228,7 +228,17 @@ static void test_peerpidfd(void) {
         wait_and_verify(pid_client);
 }
 
+static void test_peergroups(void) {
+        gid_t gids[] = { 4, 2, 4, 3, 2 };
+
+        c_assert(sockopt_sort_unique_gids(gids, sizeof(gids) / sizeof(gids[0])) == 3);
+        c_assert(gids[0] == 2);
+        c_assert(gids[1] == 3);
+        c_assert(gids[2] == 4);
+}
+
 int main(int argc, char **argv) {
+        test_peergroups();
         test_peerpidfd();
         return 0;
 }


### PR DESCRIPTION
### Patch Description
- Adds `sockopt_sort_unique_gids()` to sort and deduplicate peer group GIDs.
- Updates `sockopt_get_peergroups()` to use the helper and return the correct deduped count.
- Shrinks the allocated GID buffer when duplicate entries are removed.
- Adds a small regression test for duplicate GID handling in test-sockopt.c.

### Benefit
- Prevents stale duplicate group IDs from being processed.
- Ensures authorization decisions use the correct peer group list.
- Improves determinism and memory usage for `SO_PEERGROUPS` results.