### PR TITLE
Add unstable builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ env:
     -D docs=true
     -D launcher=true
     -D selinux=true
+    -D unstable=true
 
 jobs:
   #
@@ -241,6 +242,7 @@ jobs:
             -D docs=false
             -D launcher=false
             -D selinux=false
+            -D unstable=false
 
         # A reduced build with `-O0` to verify we do not rely on dead-code
         # elimination.

--- a/meson.build
+++ b/meson.build
@@ -168,6 +168,15 @@ use_tests = get_option('tests')
 conf.set('testdir', get_option('prefix') / 'lib/dbus-broker/tests')
 
 #
+# Config: unstable
+#
+
+use_unstable = get_option('unstable')
+if use_unstable
+        add_project_arguments('-DDBUS_BROKER_UNSTABLE=1', language: 'c')
+endif
+
+#
 # Global Parameters
 #
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,4 @@ option('reference-test', type: 'boolean', value: false, description: 'Run test s
 option('selinux', type: 'boolean', value: false, description: 'SELinux support')
 option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')
 option('tests', type: 'boolean', value: false, description: 'Include tests in the distribution')
+option('unstable', type: 'boolean', value: false, description: 'Enable unstable features')


### PR DESCRIPTION
Add an `unstable` option to allow building unstable code, but leave it out of distributions.