### PR TITLE
util/apparmor: fix malformed dbus_bind audit record

### DIFF
--- a/src/util/apparmor.c
+++ b/src/util/apparmor.c
@@ -166,7 +166,8 @@ int bus_apparmor_set_bus_type(BusAppArmorRegistry *registry, const char *bustype
         return 0;
 }
 
-static int bus_apparmor_log(
+/* Annotated as printf-like so -Wformat validates the audit records built below. */
+static int _c_printf_(3, 4) bus_apparmor_log(
         BusAppArmorRegistry *registry,
         uid_t uid,
         const char *fmt,
@@ -425,7 +426,7 @@ int bus_apparmor_check_own(
                         " operation=\"dbus_bind\""
                         " bus=\"%s\""
                         " name=\"%s\""
-                        " mask=\"bind\"",
+                        " mask=\"bind\""
                         " label=\"%s\"",
                         allow ? "ALLOWED" : "DENIED",
                         registry->bustype,


### PR DESCRIPTION
A stray comma in the `dbus_bind` AppArmor audit log split the format
string, so `label="%s"` got passed as an argument instead of being
printed. The result: the ALLOWED/DENIED verdict lands in the `bus`
field, the bus type in `name`, and the peer's label and requested name
are dropped from the record entirely.

This slipped past `-Wall -Werror` because `bus_apparmor_log()` isn't
marked printf-like, so `-Wformat` never checked it. I added the
`_c_printf_(3, 4)` attribute (which now validates all five call sites)
and removed the comma. The other four records were already correct, so
it still builds clean.

Tested: `meson test` 47/47 green.
