### PR TITLE
dbus/message: avoid alloca() when parsing the body signature

### DIFF
--- a/src/dbus/message.c
+++ b/src/dbus/message.c
@@ -368,18 +368,23 @@ static int message_parse_header(Message *message, MessageMetadata *metadata) {
 static int message_parse_body(Message *message, MessageMetadata *metadata) {
         _c_cleanup_(c_dvar_deinit) CDVar v = C_DVAR_INIT;
         const char *signature = metadata->fields.signature;
+        CDVarType types[256];
         size_t i, n_signature, n_types;
-        CDVarType *t, *types;
+        CDVarType *t;
         int r;
 
         /*
-         * Parse body-signature into CDVarType array. We use a single array
-         * with all the argument-types concatenated.
+         * Parse body-signature into a single CDVarType array with all the
+         * argument-types concatenated. A D-Bus signature is limited to 255
+         * characters and maps to exactly one CDVarType entry per character, so
+         * this fixed on-stack array is always sufficient. It avoids a
+         * variable-length stack allocation on this untrusted-input path and
+         * keeps the bound enforced even when assertions are compiled out.
          */
 
         n_signature = strlen(signature);
-        c_assert(n_signature < 256);
-        types = alloca(n_signature * sizeof(CDVarType));
+        if (n_signature >= C_ARRAY_SIZE(types))
+                return MESSAGE_E_INVALID_HEADER;
         n_types = 0;
 
         for (i = 0; i < n_signature; i += types[i].length) {


### PR DESCRIPTION

The body-signature parser allocated its CDVarType scratch array with
alloca(), sized from the message signature. alloca() has no failure mode,
is a stack-clash primitive, and is routinely flagged by the static
analyzers run in CI (CodeQL, Coverity) -- undesirable on a path that
processes untrusted message input.

A D-Bus signature is limited to 255 characters and each character maps to
exactly one CDVarType entry, so a fixed 256-entry (1 KiB) on-stack array
is always large enough. Use such an array and reject up front any
signature that would not fit. The previous bound was only checked via
c_assert(), which is compiled out in NDEBUG builds; the explicit check
keeps it enforced in all builds while dropping the variable-length
allocation entirely. No behavior changes for valid messages.
