### PR TITLE
util/string: reject negative values in unsigned integer parsers

### DIFF
--- a/src/broker/main.c
+++ b/src/broker/main.c
@@ -129,7 +129,7 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_MAX_BYTES:
                         r = util_strtou64(&main_arg_max_bytes, optarg);
-                        if (r) {
+                        if (r || (main_arg_max_bytes > UINT32_MAX && main_arg_max_bytes != UINT64_MAX)) {
                                 fprintf(stderr, "%s: invalid max number of bytes -- '%s'\n", program_invocation_name, optarg);
                                 return MAIN_FAILED;
                         }
@@ -138,7 +138,7 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_MAX_FDS:
                         r = util_strtou64(&main_arg_max_fds, optarg);
-                        if (r) {
+                        if (r || (main_arg_max_fds > UINT32_MAX && main_arg_max_fds != UINT64_MAX)) {
                                 fprintf(stderr, "%s: invalid max number of fds -- '%s'\n", program_invocation_name, optarg);
                                 return MAIN_FAILED;
                         }
@@ -147,7 +147,7 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_MAX_MATCHES:
                         r = util_strtou64(&main_arg_max_matches, optarg);
-                        if (r) {
+                        if (r || (main_arg_max_matches > UINT32_MAX && main_arg_max_matches != UINT64_MAX)) {
                                 fprintf(stderr, "%s: invalid max number of matches -- '%s'\n", program_invocation_name, optarg);
                                 return MAIN_FAILED;
                         }
@@ -156,7 +156,7 @@ static int parse_argv(int argc, char *argv[]) {
 
                 case ARG_MAX_OBJECTS:
                         r = util_strtou64(&main_arg_max_objects, optarg);
-                        if (r) {
+                        if (r || (main_arg_max_objects > UINT32_MAX && main_arg_max_objects != UINT64_MAX)) {
                                 fprintf(stderr, "%s: invalid max number of objects -- '%s'\n", program_invocation_name, optarg);
                                 return MAIN_FAILED;
                         }

--- a/src/launch/config.c
+++ b/src/launch/config.c
@@ -1165,8 +1165,14 @@ static void config_parser_end_fn(void *userdata, const XML_Char *name) {
 
         case CONFIG_NODE_LIMIT:
                 r = util_strtou64(&state->current->limit.value, state->current->cdata);
-                if (r)
-                        CONFIG_ERR(state, "Invalid limit value", ": %s", state->current->cdata);
+                if (r) {
+                        if (r == UTIL_STRING_E_RANGE)
+                                CONFIG_ERR(state, "Limit value out of range", ": %s", state->current->cdata);
+                        else
+                                CONFIG_ERR(state, "Invalid limit value", ": %s", state->current->cdata);
+                } else if (state->current->limit.value > UINT32_MAX && state->current->limit.value != UINT64_MAX) {
+                        CONFIG_ERR(state, "Limit value out of range", ": %s", state->current->cdata);
+                }
 
                 break;
 

--- a/src/util/string.c
+++ b/src/util/string.c
@@ -15,7 +15,20 @@ int util_strtou32(uint32_t *valp, const char *string) {
         unsigned long val;
         char *end;
 
+        const char *p = string;
+
         static_assert(sizeof(val) >= sizeof(uint32_t), "unsigned long is less than 32 bits");
+
+        while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == '\v' || *p == '\f')
+                p++;
+
+        if (*p == '-') {
+                if (p[1] == '1' && (p[2] == '\0' || p[2] == ' ' || p[2] == '\t' || p[2] == '\n' || p[2] == '\r')) {
+                        *valp = UINT32_MAX;
+                        return 0;
+                }
+                return UTIL_STRING_E_INVALID;
+        }
 
         errno = 0;
         val = strtoul(string, &end, 10);
@@ -39,7 +52,20 @@ int util_strtou64(uint64_t *valp, const char *string) {
         unsigned long long val;
         char *end;
 
+        const char *p = string;
+
         static_assert(sizeof(val) >= sizeof(uint64_t), "unsigned long long is less than 64 bits");
+
+        while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == '\v' || *p == '\f')
+                p++;
+
+        if (*p == '-') {
+                if (p[1] == '1' && (p[2] == '\0' || p[2] == ' ' || p[2] == '\t' || p[2] == '\n' || p[2] == '\r')) {
+                        *valp = UINT64_MAX;
+                        return 0;
+                }
+                return UTIL_STRING_E_INVALID;
+        }
 
         errno = 0;
         val = strtoull(string, &end, 10);


### PR DESCRIPTION
Improve util_strtou32 and util_strtou64 to validate negative signs.
Only the "-1" sentinel is allowed (mapping to UINT32_MAX/UINT64_MAX
for unlimited capacity), while all other negative numbers (such as
"-2" or "-100") are rejected. 

This prevents integer overflow bypasses when parsing configurations
or command-line limits.
