### PR TITLE
util/string: reject negative inputs in unsigned integer parsers

### DIFF
--- a/src/util/string.c
+++ b/src/util/string.c
@@ -5,6 +5,7 @@
  * String Helpers
  */
 
+#include <ctype.h>
 #include <c-stdaux.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -16,6 +17,15 @@ int util_strtou32(uint32_t *valp, const char *string) {
         char *end;
 
         static_assert(sizeof(val) >= sizeof(uint32_t), "unsigned long is less than 32 bits");
+
+        if (!string)
+                return UTIL_STRING_E_INVALID;
+
+        while (isspace((unsigned char)*string))
+                string++;
+
+        if (*string == '-')
+                return UTIL_STRING_E_INVALID;
 
         errno = 0;
         val = strtoul(string, &end, 10);
@@ -40,6 +50,15 @@ int util_strtou64(uint64_t *valp, const char *string) {
         char *end;
 
         static_assert(sizeof(val) >= sizeof(uint64_t), "unsigned long long is less than 64 bits");
+
+        if (!string)
+                return UTIL_STRING_E_INVALID;
+
+        while (isspace((unsigned char)*string))
+                string++;
+
+        if (*string == '-')
+                return UTIL_STRING_E_INVALID;
 
         errno = 0;
         val = strtoull(string, &end, 10);

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -18,6 +18,7 @@ enum {
         UTIL_STRING_E_RANGE,
 };
 
+/* Unsigned parsing functions reject negative values (returning UTIL_STRING_E_INVALID). */
 int util_strtou32(uint32_t *valp, const char *string);
 int util_strtou64(uint64_t *valp, const char *string);
 int util_strtoint(int *valp, const char *string);

--- a/src/util/test-misc.c
+++ b/src/util/test-misc.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include "util/misc.h"
+#include "util/string.h"
 
 /*
  * Check for which memfd-seals are supported by the running kernel and return
@@ -214,10 +215,45 @@ static void test_vfreep(void) {
         misc_vfreep(&v);
 }
 
+static void test_string(void) {
+        uint32_t u32;
+        uint64_t u64;
+        int i;
+
+        /* Test positive numbers */
+        c_assert(util_strtou32(&u32, "123") == 0);
+        c_assert(u32 == 123);
+
+        /* Test negative numbers (should fail) */
+        c_assert(util_strtou32(&u32, "-1") == UTIL_STRING_E_INVALID);
+        c_assert(util_strtou32(&u32, "  -1") == UTIL_STRING_E_INVALID);
+        c_assert(util_strtou64(&u64, "-1") == UTIL_STRING_E_INVALID);
+        c_assert(util_strtou64(&u64, "  -1") == UTIL_STRING_E_INVALID);
+
+        /* Test signed parsing (should work) */
+        c_assert(util_strtoint(&i, "-5") == 0);
+        c_assert(i == -5);
+
+        /* Test overflow */
+        c_assert(util_strtou32(&u32, "4294967296") == UTIL_STRING_E_RANGE);
+
+        /* Test empty string */
+        c_assert(util_strtou32(&u32, "") == UTIL_STRING_E_INVALID);
+
+        /* Test plus sign */
+        c_assert(util_strtou32(&u32, "+123") == 0);
+        c_assert(u32 == 123);
+
+        /* Test spaces */
+        c_assert(util_strtou32(&u32, "  123  ") == 0);
+        c_assert(u32 == 123);
+}
+
 int main(int argc, char **argv) {
         test_memfd();
         test_umul_saturating();
         test_casts();
         test_vfreep();
+        test_string();
         return 0;
 }

--- a/src/util/test-misc.c
+++ b/src/util/test-misc.c
@@ -223,6 +223,8 @@ static void test_string(void) {
         /* Test positive numbers */
         c_assert(util_strtou32(&u32, "123") == 0);
         c_assert(u32 == 123);
+        c_assert(util_strtou64(&u64, "123") == 0);
+        c_assert(u64 == 123);
 
         /* Test negative numbers (should fail) */
         c_assert(util_strtou32(&u32, "-1") == UTIL_STRING_E_INVALID);
@@ -236,6 +238,7 @@ static void test_string(void) {
 
         /* Test overflow */
         c_assert(util_strtou32(&u32, "4294967296") == UTIL_STRING_E_RANGE);
+        c_assert(util_strtou64(&u64, "18446744073709551616") == UTIL_STRING_E_RANGE);
 
         /* Test empty string */
         c_assert(util_strtou32(&u32, "") == UTIL_STRING_E_INVALID);
@@ -244,9 +247,11 @@ static void test_string(void) {
         c_assert(util_strtou32(&u32, "+123") == 0);
         c_assert(u32 == 123);
 
-        /* Test spaces */
-        c_assert(util_strtou32(&u32, "  123  ") == 0);
+        /* Test spaces: leading spaces are allowed, trailing spaces are not */
+        c_assert(util_strtou32(&u32, "  123") == 0);
         c_assert(u32 == 123);
+        c_assert(util_strtou32(&u32, "123  ") == UTIL_STRING_E_INVALID);
+        c_assert(util_strtou32(&u32, "  123  ") == UTIL_STRING_E_INVALID);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Reject negative inputs in util_strtou32 and util_strtou64. Currently, passing negative values like "-1" results in a silent wrap-around to ULONG_MAX because of how strtoul/strtoull operate. 

This patch hardens both unsigned helpers to explicitly return UTIL_STRING_E_INVALID if a minus sign is present. I've also added tests in test-misc.c to verify this change along with other basic formatting and overflow edge cases.
