### PR TITLE
util/string: reject negative numbers in util_strtou32/64

### DIFF
--- a/src/util/string.c
+++ b/src/util/string.c
@@ -11,11 +11,26 @@
 #include "util/error.h"
 #include "util/string.h"
 
+static bool string_is_negative(const char *string) {
+        while (*string == ' ' || (*string >= '\t' && *string <= '\r'))
+                string++;
+        if (*string == '-') {
+                string++;
+                while (*string == '0')
+                        string++;
+                return *string >= '1' && *string <= '9';
+        }
+        return false;
+}
+
 int util_strtou32(uint32_t *valp, const char *string) {
         unsigned long val;
         char *end;
 
         static_assert(sizeof(val) >= sizeof(uint32_t), "unsigned long is less than 32 bits");
+
+        if (string_is_negative(string))
+                return UTIL_STRING_E_INVALID;
 
         errno = 0;
         val = strtoul(string, &end, 10);
@@ -40,6 +55,9 @@ int util_strtou64(uint64_t *valp, const char *string) {
         char *end;
 
         static_assert(sizeof(val) >= sizeof(uint64_t), "unsigned long long is less than 64 bits");
+
+        if (string_is_negative(string))
+                return UTIL_STRING_E_INVALID;
 
         errno = 0;
         val = strtoull(string, &end, 10);

--- a/src/util/test-misc.c
+++ b/src/util/test-misc.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include "util/misc.h"
+#include "util/string.h"
 
 /*
  * Check for which memfd-seals are supported by the running kernel and return
@@ -213,11 +214,20 @@ static void test_vfreep(void) {
         c_assert(v[0] && v[1]);
         misc_vfreep(&v);
 }
+static void test_strtou_negative_values(void) {
+        uint32_t u;
+        uint64_t g;
+        c_assert(util_strtou32(&u, "-1") == UTIL_STRING_E_INVALID);
+        c_assert(util_strtou32(&u, "-0") == 0 && u == 0);
+        c_assert(util_strtou64(&g, " -1 ") == UTIL_STRING_E_INVALID);
+}
+
 
 int main(int argc, char **argv) {
         test_memfd();
         test_umul_saturating();
         test_casts();
         test_vfreep();
+        test_strtou_negative_values();
         return 0;
 }


### PR DESCRIPTION
While auditing the string parsing utilities in src/util/string.c, I noticed that util_strtou32 and util_strtou64 use strtoul/strtoull directly without validating whether the input string has a negative sign.

Because of standard C library behavior, passing negative values (e.g., "-1" or "-4294967295") parses successfully as very large unsigned integers due to silent modulo arithmetic conversion. In resource limit configurations or parsing contexts, this behavior can allow users to inadvertently bypass limits.

To fix this, I added a lightweight string_is_negative() check at the beginning of the unsigned parsing helpers to reject strictly negative values while continuing to allow valid negative zero (-0) variations. I also added a corresponding test case in test-misc.c to verify this validation.
